### PR TITLE
Automatic refresh token

### DIFF
--- a/simplipy/account.py
+++ b/simplipy/account.py
@@ -5,7 +5,7 @@ from typing import List, Union  # noqa
 
 from aiohttp import BasicAuth, ClientSession, client_exceptions
 
-from .errors import RequestError, TokenExpiredError
+from .errors import RequestError
 from .system import System, SystemV2, SystemV3  # noqa
 
 DEFAULT_USER_AGENT = 'SimpliSafe/2105 CFNetwork/902.2 Darwin/17.7.0'
@@ -89,10 +89,8 @@ class SimpliSafe:
     async def refresh_access_token(self, refresh_token: str = None) -> None:
         """Regenerate an access token using the stored refresh token."""
         await self._authenticate({
-            'grant_type':
-                'refresh_token',
-            'username':
-                self._email,
+            'grant_type': 'refresh_token',
+            'username': self._email,
             'refresh_token':
                 refresh_token if refresh_token else self.refresh_token,
         })
@@ -110,7 +108,7 @@ class SimpliSafe:
         """Make a request."""
         if (self._access_token_expire
                 and datetime.now() >= self._access_token_expire):
-            raise TokenExpiredError('The access token has expired')
+            await self.refresh_access_token()
 
         url = '{0}/{1}'.format(URL_BASE, endpoint)
 

--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -11,9 +11,3 @@ class RequestError(SimplipyError):
     """Define an error related to invalid requests."""
 
     pass
-
-
-class TokenExpiredError(SimplipyError):
-    """Define an error for expired access tokens."""
-
-    pass

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -8,7 +8,7 @@ import pytest
 
 from simplipy import get_systems
 from simplipy.account import SimpliSafe
-from simplipy.errors import RequestError, TokenExpiredError
+from simplipy.errors import RequestError
 from simplipy.system import System
 
 from .const import (
@@ -34,7 +34,7 @@ async def test_bad_request(api_token_json, event_loop, v2_server):
 
 
 @pytest.mark.asyncio
-async def test_expired_token_exception(event_loop, v2_server):
+async def test_expired_token_refresh(event_loop, v2_server):
     """Test that the correct exception is raised when the token is expired."""
     async with v2_server:
         v2_server.add(


### PR DESCRIPTION
In order to more fully support the Home Assistant use case, this PR makes the following changes:

1. The library implemented no longer has to manually catch a `TokenExpiredError` and refresh the access token; that is done automatically.
2. Instead of a `get_systems()` method, the `SimpliSafe` object now provides class methods for instantiation via username/password _or_ refresh token.