### PR TITLE
Re-architect triggered meaning for v2 sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ async def main() -> None:
           sensor.low_battery
           # >>> False
 
-          # Return whether the sensor has been triggered:
+          # Return whether the sensor has been triggered (open/closed, etc.):
           sensor.triggered
           # >>> False
 

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -78,11 +78,6 @@ class SensorV2(Sensor):
         return self.sensor_data['setting']
 
     @property
-    def status(self) -> int:
-        """Return the sensor's status (unknown meaning)."""
-        return self.sensor_data['sensorStatus']
-
-    @property
     def triggered(self) -> bool:
         """Return the current sensor state."""
         if self.type == SensorTypes.entry:

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -3,6 +3,8 @@ import logging
 from enum import Enum
 from typing import Union
 
+from .errors import SimplipyError
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -76,9 +78,19 @@ class SensorV2(Sensor):
         return self.sensor_data['setting']
 
     @property
+    def status(self) -> int:
+        """Return the sensor's status (unknown meaning)."""
+        return self.sensor_data['sensorStatus']
+
+    @property
     def triggered(self) -> bool:
         """Return the current sensor state."""
-        return self.sensor_data.get('sensorStatus', 0) != 0
+        if self.type == SensorTypes.entry:
+            return self.sensor_data.get('entryStatus', 'closed') == 'open'
+
+        raise SimplipyError(
+            'Cannot determine triggered state for sensor: {0}'.format(
+                self.name))
 
 
 class SensorV3(Sensor):

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,6 +5,7 @@ import aiohttp
 import pytest
 
 from simplipy import API
+from simplipy.errors import SimplipyError
 from simplipy.sensor import SensorTypes
 
 from .const import TEST_EMAIL, TEST_PASSWORD
@@ -37,12 +38,23 @@ async def test_properties_v2(event_loop, v2_server):
                 TEST_EMAIL, TEST_PASSWORD, websession)
             [system] = await api.get_systems()
 
-            sensor = system.sensors['195']
-            assert sensor.data == 0
-            assert not sensor.error
-            assert not sensor.low_battery
-            assert sensor.settings == 1
-            assert not sensor.triggered
+            keypad = system.sensors['195']
+            assert keypad.data == 0
+            assert not keypad.error
+            assert not keypad.low_battery
+            assert keypad.settings == 1
+
+            # Ensure that attempting to access the triggered of anything but
+            # an entry sensor in a V2 system throws an error:
+            with pytest.raises(SimplipyError):
+                assert keypad.triggered == 42
+
+            entry_sensor = system.sensors['609']
+            assert entry_sensor.data == 210
+            assert not entry_sensor.error
+            assert not entry_sensor.low_battery
+            assert entry_sensor.settings == 1
+            assert not entry_sensor.triggered
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Follow up to https://github.com/bachya/simplisafe-python/pull/8. This PR tries to make some more sense of what "triggered" looks like in V2 data. Tactically, there are two changes:

* Entry sensors will use the `entryStatus` property from the response data.
* Any other sensors will raise an exception (until we can determine how their triggered status is communicated via the API).

**Does this fix a specific issue?**

N/A

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.