### PR TITLE
Added a `trigger_instantly` property to V2 and V3 systems

### DIFF
--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -78,6 +78,11 @@ class SensorV2(Sensor):
         return self.sensor_data['setting']
 
     @property
+    def trigger_instantly(self) -> bool:
+        """Return whether the sensor will trigger instantly."""
+        return self.sensor_data['instant']
+
+    @property
     def triggered(self) -> bool:
         """Return the current sensor state."""
         if self.type == SensorTypes.entry:
@@ -110,6 +115,11 @@ class SensorV3(Sensor):
     def settings(self) -> dict:
         """Return the sensor's settings."""
         return self.sensor_data['setting']
+
+    @property
+    def trigger_instantly(self) -> bool:
+        """Return whether the sensor will trigger instantly."""
+        return self.sensor_data['setting']['instantTrigger']
 
     @property
     def triggered(self) -> bool:

--- a/tests/fixtures/v2.py
+++ b/tests/fixtures/v2.py
@@ -231,7 +231,7 @@ def v2_settings_json():
                 "entryStatus": "closed"
             }, {
                 "type": 5,
-                "serial": "609",
+                "serial": "610",
                 "setting": 1,
                 "instant": False,
                 "enotify": False,

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -50,10 +50,11 @@ async def test_properties_v2(event_loop, v2_server):
                 assert keypad.triggered == 42
 
             entry_sensor = system.sensors['609']
-            assert entry_sensor.data == 210
+            assert entry_sensor.data == 130
             assert not entry_sensor.error
             assert not entry_sensor.low_battery
             assert entry_sensor.settings == 1
+            assert not entry_sensor.trigger_instantly
             assert not entry_sensor.triggered
 
 
@@ -71,6 +72,7 @@ async def test_properties_v3(event_loop, v3_server):
             assert not entry_sensor.low_battery
             assert not entry_sensor.offline
             assert not entry_sensor.settings['instantTrigger']
+            assert not entry_sensor.trigger_instantly
             assert not entry_sensor.triggered
 
             siren = system.sensors['236']

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -114,7 +114,7 @@ async def test_get_systems_v2(
             assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
             assert primary_system.system_id == TEST_SYSTEM_ID
             assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 34
+            assert len(primary_system.sensors) == 35
 
             token_api = await API.login_via_token(
                 TEST_REFRESH_TOKEN, websession)
@@ -125,7 +125,7 @@ async def test_get_systems_v2(
             assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
             assert primary_system.system_id == TEST_SYSTEM_ID
             assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 34
+            assert len(primary_system.sensors) == 35
 
 
 @pytest.mark.asyncio
@@ -338,7 +338,7 @@ async def test_update_system_data_v2(
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
             assert system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(system.sensors) == 34
+            assert len(system.sensors) == 35
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a `trigger_instantly` property for each sensor.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.
