### PR TITLE
Add dirtiness check for refresh token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 coverage:
 	pipenv run py.test -s --verbose --cov-report term-missing --cov-report xml --cov=simplipy tests
 init:
-	pip install --upgrade pip pipenv
+	pip install pip==18.0 pipenv
 	pipenv lock
 	pipenv install --dev
 lint:

--- a/README.md
+++ b/README.md
@@ -351,6 +351,36 @@ asyncio.get_event_loop().run_until_complete(main())
 
 # Refreshing the Access Token
 
+## General Notes
+
+During usage, `simplipy` will automatically refresh the access token as needed.
+At any point, the "dirtiness" of the token can be checked:
+
+```python
+from simplipy import API
+
+
+async def main() -> None:
+    """Create the aiohttp session and run."""
+    async with ClientSession() as websession:
+      simplisafe = API.login_via_token("<REFRESH TOKEN>", websession)
+      systems = await simplisafe.get_systems()
+      primary_system = systems[0]
+
+      # Assuming the access token was automatically refreshed:
+      primary_system.api.refresh_token_dirty
+      # >>> True
+
+      # Once the dirtiness is confirmed, the dirty bit resets:
+      primary_system.api.refresh_token_dirty
+      # >>> False
+
+
+asyncio.get_event_loop().run_until_complete(main())
+```
+
+## Restarting with a Refresh Token
+
 It may be desirable to re-authenticate against the SimpliSafe™ API at some
 point in the future (and without using a user's email and password). In that
 case, it is recommended that you save the `refresh_token` property somewhere;

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = True
 whitelist_externals = make
 deps = pipenv
 commands=
+    pipenv run pip install pip==18.0
     make init
     make test
 
@@ -13,6 +14,7 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
+    pipenv run pip install pip==18.0
     make init
     make coverage
 
@@ -20,6 +22,7 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
+    pipenv run pip install pip==18.0
     make init
     make lint
 
@@ -27,5 +30,6 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
+    pipenv run pip install pip==18.0
     make init
     make typing

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ skip_missing_interpreters = True
 whitelist_externals = make
 deps = pipenv
 commands=
-    pipenv run pip install pip==18.0
     make init
     make test
 
@@ -14,7 +13,6 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
-    pipenv run pip install pip==18.0
     make init
     make coverage
 
@@ -22,7 +20,6 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
-    pipenv run pip install pip==18.0
     make init
     make lint
 
@@ -30,6 +27,5 @@ commands=
 whitelist_externals = make
 deps = pipenv
 commands=
-    pipenv run pip install pip==18.0
     make init
     make typing


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the ability to check the "dirtiness" of the refresh token (i.e., whether it has been changed or not). This allows applications that store refresh tokens to a filesystem, database, etc. to not constantly:

1. Read from the filesystem/DB
2. Determine whether the refresh token has changed
3. Save the new one to the filesystem/DB

Since the token won't change a large portion of the time, this is wasteful. Instead, at any point, library users can check for themselves:

```python
system.api.refresh_token_dirty
# >>> True
```

Note that this does create something of an [observer effect](https://en.wikipedia.org/wiki/Observer_effect_(physics)): by viewing the dirtiness property, we automatically reset it to `False`.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.
