### PR TITLE
Fix a bug where not all exceptions were caught properly

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -5,7 +5,8 @@
 from datetime import datetime, timedelta
 from typing import List, Type, TypeVar, Union  # noqa
 
-from aiohttp import BasicAuth, ClientSession, client_exceptions
+from aiohttp import BasicAuth, ClientSession
+from aiohttp.client_exceptions import ClientError
 
 from .errors import RequestError
 from .system import System, SystemV2, SystemV3  # noqa
@@ -154,13 +155,12 @@ class API:
             'User-Agent': DEFAULT_USER_AGENT,
         })
 
-        async with self._websession.request(method, url, headers=headers,
-                                            params=params, data=data,
-                                            json=json, **kwargs) as resp:
-            try:
+        try:
+            async with self._websession.request(
+                    method, url, headers=headers, params=params, data=data,
+                    json=json, **kwargs) as resp:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
-            except client_exceptions.ClientError as err:
-                raise RequestError(
-                    'Error requesting data from {0}: {1}'.format(
-                        endpoint, err)) from None
+        except ClientError as err:
+            raise RequestError(
+                'Error requesting data from {0}: {1}'.format(endpoint, err))


### PR DESCRIPTION
**Describe what the PR does:**

Previously, the library didn't catch all `ClientError` exceptions from `aiohttp`. This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests is written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [ ] Ensure you have no linting errors: `make lint` (after running `make init`)
- [ ] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [ ] Add yourself to `AUTHORS.md`.
