### PR TITLE
Fix a bug where unsupported features would throw unhandled exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,24 @@ If you wish to continue using the previous, synchronous version of
 However, running the test suite currently requires Python 3.6 or higher; tests
 run on Python 3.5 will fail.
 
+# Standard vs. Interactive SimpliSafe™ Plans
+
+SimpliSafe™ offers two different monitoring plans:
+
+>**Standard:** Monitoring specialists guard your home around-the-clock from
+>our award-winning monitoring centers. In an emergency, we send the police to
+>your home. Free cellular connection built-in.
+
+>**Interactive:** Standard + advanced mobile app control of your system from
+>anywhere in the world. Get text + email alerts, monitor home activity,
+>arm/disarm your system, control settings right on your smartphone or laptop.
+>Bonus: Secret! Alerts—get secretly notified when anyone accesses private
+>rooms, drawers, safes and more.
+
+Please note that only Interactive plans can access sensor values and set the
+system state; using the API with a Standard plan will be limited to retrieving
+the current system state.
+
 # Installation
 
 ```python

--- a/example.py
+++ b/example.py
@@ -53,7 +53,7 @@ async def main() -> None:
     async with ClientSession() as websession:
         try:
             print()
-            await exercise_client('suresh.kalavala@outlook.com', 'Q+ynx52hzV_4', websession)
+            await exercise_client('<EMAIL>', '<PASSWORD>', websession)
         except SimplipyError as err:
             print(err)
 

--- a/example.py
+++ b/example.py
@@ -53,7 +53,7 @@ async def main() -> None:
     async with ClientSession() as websession:
         try:
             print()
-            await exercise_client('<EMAIL>', '<PASSWORD>', websession)
+            await exercise_client('suresh.kalavala@outlook.com', 'Q+ynx52hzV_4', websession)
         except SimplipyError as err:
             print(err)
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -71,3 +71,15 @@ def events_json():
             "video": {}
         }]
     }
+
+
+@pytest.fixture()
+def unavailable_feature_json():
+    """Return a response to amn unavailable request."""
+    return {
+        "errorType": "NoRemoteManagement",
+        "code": 403,
+        "message":
+            "Subscription {0} does not support remote management".format(
+                TEST_SUBSCRIPTION_ID)
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,164 @@
+"""Define tests for the System object."""
+# pylint: disable=protected-access,redefined-outer-name,too-many-arguments
+import json
+from datetime import datetime, timedelta
+
+import aiohttp
+import aresponses
+import pytest
+
+from simplipy import API
+from simplipy.errors import RequestError
+
+from .const import (
+    TEST_EMAIL, TEST_PASSWORD, TEST_REFRESH_TOKEN, TEST_SUBSCRIPTION_ID,
+    TEST_USER_ID)
+from .fixtures import *  # noqa
+from .fixtures.v2 import *  # noqa
+from .fixtures.v3 import *  # noqa
+
+
+@pytest.mark.asyncio
+async def test_bad_request(event_loop, v2_server):
+    """Test that a generic error is thrown when a request fails."""
+    async with v2_server:
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/fakeEndpoint', 'get',
+            aresponses.Response(text='', status=404))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
+            [system] = await api.get_systems()
+            with pytest.raises(RequestError):
+                await system.api.request('get', 'api/fakeEndpoint')
+
+
+@pytest.mark.asyncio
+async def test_expired_token_refresh(
+        api_token_json, auth_check_json, event_loop, v2_server):
+    """Test that a refresh token is used correctly."""
+    async with v2_server:
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/token', 'post',
+            aresponses.Response(text=json.dumps(api_token_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
+            [system] = await api.get_systems()
+            system.api._access_token_expire = datetime.now() - timedelta(
+                hours=1)
+            await system.api.request('get', 'api/authCheck')
+
+
+@pytest.mark.asyncio
+async def test_refresh_token_dirtiness(
+        api_token_json, auth_check_json, event_loop, v2_server):
+    """Test that the refresh token's dirtiness can be checked."""
+    async with v2_server:
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/token', 'post',
+            aresponses.Response(text=json.dumps(api_token_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
+            [system] = await api.get_systems()
+            system.api._access_token_expire = datetime.now() - timedelta(
+                hours=1)
+            await system.api.request('get', 'api/authCheck')
+
+            assert system.api.refresh_token_dirty
+            assert system.api.refresh_token == TEST_REFRESH_TOKEN
+            assert not system.api.refresh_token_dirty
+
+
+@pytest.mark.asyncio
+async def test_unavailable_feature_v2(
+        api_token_json, auth_check_json, caplog, event_loop, v2_server,
+        v2_subscriptions_json, unavailable_feature_json):
+    """Test that a message is logged with an unavailable feature."""
+    async with v2_server:
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/token', 'post',
+            aresponses.Response(text=json.dumps(api_token_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com',
+            '/v1/users/{0}/subscriptions'.format(TEST_USER_ID), 'get',
+            aresponses.Response(
+                text=json.dumps(v2_subscriptions_json), status=200))
+        v2_server.add(
+            'api.simplisafe.com',
+            '/v1/subscriptions/{0}/settings'.format(TEST_SUBSCRIPTION_ID),
+            'get',
+            aresponses.Response(
+                text=json.dumps(unavailable_feature_json), status=403))
+        v2_server.add(
+            'api.simplisafe.com',
+            '/v1/subscriptions/{0}/state'.format(TEST_SUBSCRIPTION_ID), 'post',
+            aresponses.Response(
+                text=json.dumps(unavailable_feature_json), status=403))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
+            [system] = await api.get_systems()
+            await system.update()
+            await system.set_away()
+            logs = ['not available' in e.message for e in caplog.records]
+            assert len(logs) == 3
+
+
+@pytest.mark.asyncio
+async def test_unavailable_feature_v3(
+        api_token_json, auth_check_json, caplog, event_loop, v3_server,
+        v3_subscriptions_json, unavailable_feature_json):
+    """Test that a message is logged with an unavailable feature."""
+    async with v3_server:
+        v3_server.add(
+            'api.simplisafe.com', '/v1/api/token', 'post',
+            aresponses.Response(text=json.dumps(api_token_json), status=200))
+        v3_server.add(
+            'api.simplisafe.com', '/v1/api/authCheck', 'get',
+            aresponses.Response(text=json.dumps(auth_check_json), status=200))
+        v3_server.add(
+            'api.simplisafe.com',
+            '/v1/users/{0}/subscriptions'.format(TEST_USER_ID), 'get',
+            aresponses.Response(
+                text=json.dumps(v3_subscriptions_json), status=200))
+        v3_server.add(
+            'api.simplisafe.com',
+            '/v1/ss3/subscriptions/{0}/sensors'.format(TEST_SUBSCRIPTION_ID),
+            'get',
+            aresponses.Response(
+                text=json.dumps(unavailable_feature_json), status=403))
+        v3_server.add(
+            'api.simplisafe.com', '/v1/ss3/subscriptions/{0}/state/{1}'.format(
+                TEST_SUBSCRIPTION_ID, 'away'), 'post',
+            aresponses.Response(
+                text=json.dumps(unavailable_feature_json), status=403))
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
+            [system] = await api.get_systems()
+            await system.update()
+            await system.set_away()
+            logs = ['not available' in e.message for e in caplog.records]
+            assert len(logs) == 2


### PR DESCRIPTION
**Describe what the PR does:**

"Standard" SimpliSafe accounts don't have the ability to get sensor values or set the state. Previously, this library threw an unhandled exception when these systems attempted these actions. This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.
