### PR TITLE
Change unsupported feature log level to INFO

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -166,7 +166,7 @@ class API:
                 return await resp.json(content_type=None)
         except ClientError as err:
             if self.user_id and '403' in str(err):
-                _LOGGER.warning(
+                _LOGGER.info(
                     'Endpoint not available in this plan: %s', endpoint)
                 return {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 """Define tests for the System object."""
 # pylint: disable=protected-access,redefined-outer-name,too-many-arguments
 import json
+import logging
 from datetime import datetime, timedelta
 
 import aiohttp
@@ -91,6 +92,8 @@ async def test_unavailable_feature_v2(
         api_token_json, auth_check_json, caplog, event_loop, v2_server,
         v2_subscriptions_json, unavailable_feature_json):
     """Test that a message is logged with an unavailable feature."""
+    caplog.set_level(logging.INFO)
+
     async with v2_server:
         v2_server.add(
             'api.simplisafe.com', '/v1/api/token', 'post',
@@ -121,8 +124,12 @@ async def test_unavailable_feature_v2(
             [system] = await api.get_systems()
             await system.update()
             await system.set_away()
-            logs = ['not available' in e.message for e in caplog.records]
-            assert len(logs) == 3
+            logs = [
+                l for l in
+                ['not available' in e.message for e in caplog.records]
+                if l is not False
+            ]
+            assert len(logs) == 2
 
 
 @pytest.mark.asyncio
@@ -130,6 +137,8 @@ async def test_unavailable_feature_v3(
         api_token_json, auth_check_json, caplog, event_loop, v3_server,
         v3_subscriptions_json, unavailable_feature_json):
     """Test that a message is logged with an unavailable feature."""
+    caplog.set_level(logging.INFO)
+
     async with v3_server:
         v3_server.add(
             'api.simplisafe.com', '/v1/api/token', 'post',
@@ -160,5 +169,9 @@ async def test_unavailable_feature_v3(
             [system] = await api.get_systems()
             await system.update()
             await system.set_away()
-            logs = ['not available' in e.message for e in caplog.records]
+            logs = [
+                l for l in
+                ['not available' in e.message for e in caplog.records]
+                if l is not False
+            ]
             assert len(logs) == 2


### PR DESCRIPTION
**Describe what the PR does:**

#19 was a bit too spammy with having `WARNING` level logs. This changes the notice to be `INFO` level.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.
