### PR TITLE
Add error for bad initial credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ asyncio.get_event_loop().run_until_complete(main())
 
 # Errors/Exceptions
 
-`simplipy` exposes serveal useful error types:
+`simplipy` exposes several useful error types:
 
 * `simplipy.errors.SimplipyError`: a base error that all other `simplipy`
   errors inherit from

--- a/README.md
+++ b/README.md
@@ -360,10 +360,12 @@ asyncio.get_event_loop().run_until_complete(main())
 
 # Errors/Exceptions
 
-`simplipy` exposes two useful error types:
+`simplipy` exposes serveal useful error types:
 
 * `simplipy.errors.SimplipyError`: a base error that all other `simplipy`
   errors inherit from
+* `simplipy.errors.InvalidCredentialsError`: an error related to an invalid
+  username/password combo
 * `simplipy.errors.RequestError`: an error related to HTTP requests that return
   something other than a `200` response code
 

--- a/example.py
+++ b/example.py
@@ -6,7 +6,7 @@ import asyncio
 from aiohttp import ClientSession
 
 from simplipy import API
-from simplipy.errors import SimplipyError
+from simplipy.errors import InvalidCredentialsError, SimplipyError
 
 
 async def exercise_client(
@@ -54,6 +54,8 @@ async def main() -> None:
         try:
             print()
             await exercise_client('<EMAIL>', '<PASSWORD>', websession)
+        except InvalidCredentialsError:
+            print('Invalid credentials')
         except SimplipyError as err:
             print(err)
 

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -9,7 +9,7 @@ from typing import List, Type, TypeVar, Union  # noqa
 from aiohttp import BasicAuth, ClientSession
 from aiohttp.client_exceptions import ClientError
 
-from .errors import RequestError
+from .errors import InvalidCredentialsError, RequestError
 from .system import System, SystemV2, SystemV3  # noqa
 
 _LOGGER = logging.getLogger(__name__)
@@ -165,6 +165,8 @@ class API:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
         except ClientError as err:
+            if not self.user_id and '403' in str(err):
+                raise InvalidCredentialsError
             if self.user_id and '403' in str(err):
                 _LOGGER.info(
                     'Endpoint not available in this plan: %s', endpoint)

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -165,12 +165,12 @@ class API:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
         except ClientError as err:
-            if not self.user_id and '403' in str(err):
-                raise InvalidCredentialsError
             if self.user_id and '403' in str(err):
                 _LOGGER.info(
                     'Endpoint not available in this plan: %s', endpoint)
                 return {}
+            if not self.user_id and '403' in str(err):
+                raise InvalidCredentialsError
 
             raise RequestError(
                 'Error requesting data from {0}: {1}'.format(endpoint, err))

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -35,8 +35,8 @@ class API:
         self._access_token_expire = None  # type: Union[None, datetime]
         self._actively_refreshing = False
         self._email = None  # type: Union[None, str]
-        self._websession = websession
         self._refresh_token = ''
+        self._websession = websession
         self.refresh_token_dirty = False
         self.user_id = None
 

--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -7,6 +7,12 @@ class SimplipyError(Exception):
     pass
 
 
+class InvalidCredentialsError(SimplipyError):
+    """Define an error related to invalid requests."""
+
+    pass
+
+
 class RequestError(SimplipyError):
     """Define an error related to invalid requests."""
 

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -74,8 +74,17 @@ def events_json():
 
 
 @pytest.fixture()
+def invalid_credentials_json():
+    """Return a response related to invalid credentials."""
+    return {
+        "error": "invalid_grant",
+        "error_description": "Invalid resource owner credentials"
+    }
+
+
+@pytest.fixture()
 def unavailable_feature_json():
-    """Return a response to amn unavailable request."""
+    """Return a response related to any unavailable request."""
     return {
         "errorType": "NoRemoteManagement",
         "code": 403,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,7 +9,7 @@ import aresponses
 import pytest
 
 from simplipy import API
-from simplipy.errors import RequestError
+from simplipy.errors import InvalidCredentialsError, RequestError
 
 from .const import (
     TEST_EMAIL, TEST_PASSWORD, TEST_REFRESH_TOKEN, TEST_SUBSCRIPTION_ID,
@@ -57,6 +57,22 @@ async def test_expired_token_refresh(
             system.api._access_token_expire = datetime.now() - timedelta(
                 hours=1)
             await system.api.request('get', 'api/authCheck')
+
+
+@pytest.mark.asyncio
+async def test_invalid_credentials(
+        event_loop, invalid_credentials_json, v2_server):
+    """Test that invalid credentials throw the correct exception."""
+    async with v2_server:
+        v2_server.add(
+            'api.simplisafe.com', '/v1/api/token', 'post',
+            aresponses.Response(
+                text=json.dumps(invalid_credentials_json), status=403))
+
+    async with aiohttp.ClientSession(loop=event_loop) as websession:
+        with pytest.raises(InvalidCredentialsError):
+            await API.login_via_credentials(
+                TEST_EMAIL, TEST_PASSWORD, websession)
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -63,16 +63,16 @@ async def test_expired_token_refresh(
 async def test_invalid_credentials(
         event_loop, invalid_credentials_json, v2_server):
     """Test that invalid credentials throw the correct exception."""
-    async with v2_server:
+    async with aresponses.ResponsesMockServer(loop=event_loop) as v2_server:
         v2_server.add(
             'api.simplisafe.com', '/v1/api/token', 'post',
             aresponses.Response(
                 text=json.dumps(invalid_credentials_json), status=403))
 
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        with pytest.raises(InvalidCredentialsError):
-            await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            with pytest.raises(InvalidCredentialsError):
+                await API.login_via_credentials(
+                    TEST_EMAIL, TEST_PASSWORD, websession)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new exception for invalid credentials. It doesn't conflict with future `403` responses that might come from unavailable features.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
- [x] Add yourself to `AUTHORS.md`.
