### PR TITLE
Add support for "ALARM_COUNT" alarm state

### DIFF
--- a/simplipy/system.py
+++ b/simplipy/system.py
@@ -12,14 +12,15 @@ _LOGGER = logging.getLogger(__name__)
 class SystemStates(Enum):
     """Define states that the system can be in."""
 
-    away = 1
-    away_count = 2
-    entry_delay = 3
-    error = 4
-    exit_delay = 5
-    home = 6
-    home_count = 7
-    off = 8
+    alarm_count = 1
+    away = 2
+    away_count = 3
+    entry_delay = 4
+    error = 5
+    exit_delay = 6
+    home = 7
+    home_count = 8
+    off = 9
     unknown = 99
 
 


### PR DESCRIPTION
**Describe what the PR does:**

I got an error in my HASS logs today:

<img width="525" alt="screen shot 2018-10-22 at 12 59 29 pm" src="https://user-images.githubusercontent.com/47216/47313111-538c2080-d5fb-11e8-8537-ca6041f62421.png">

So, I added support for this state:

```
class SystemStates(Enum):
    """Define states that the system can be in."""

    alarm_count = 1
    away = 2
    away_count = 3
    entry_delay = 4
    error = 5
    exit_delay = 6
    home = 7
    home_count = 8
    off = 9
    unknown = 99
```

Because the API is unpublished, I'm uncertain if this new state is redundant, but it doesn't hurt to have it in place with the others.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have no typed your code correctly: `make typing` (after running `make init`)
