### PR TITLE
Make the access toke expire 60 seconds earlier

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -95,7 +95,7 @@ class API:
                 encoding='latin1'))
         self._access_token = token_resp['access_token']
         self._access_token_expire = datetime.now() + timedelta(
-            seconds=int(token_resp['expires_in']))
+            seconds=int(token_resp['expires_in']) - 60)
         self.refresh_token = token_resp['refresh_token']
 
         auth_check_resp = await self.request('get', 'api/authCheck')

--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -4,16 +4,10 @@
 class SimplipyError(Exception):
     """Define a base error."""
 
-    pass
-
 
 class InvalidCredentialsError(SimplipyError):
     """Define an error related to invalid requests."""
 
-    pass
-
 
 class RequestError(SimplipyError):
     """Define an error related to invalid requests."""
-
-    pass


### PR DESCRIPTION
**Describe what the PR does:**

SimpliSafe access tokens last for 1 hour. When retrieving a new access token, `simplipy` sets the expiration timestamp to be the current time + 3600 seconds. This is cutting it too close: there is a small, but present risk that such a strategy will cause`simplipy` to see an access token as valid for 1 second too long. In these cases, a `RequestError` will be raised.

This PR fools `simplipy` into thinking that access tokens will expire 60 earlier. This should allow for plenty of buffer from the time they are created to their actual expiration.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/25
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
