### PR TITLE
Make aiohttp.ClientSession optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,44 +73,45 @@ pip install simplisafe-python
 
 ## Getting Systems Associated with an Account
 
-`simplipy` starts within an
-[aiohttp](https://aiohttp.readthedocs.io/en/stable/) `ClientSession`:
-
-```python
-import asyncio
-
-from aiohttp import ClientSession
-
-
-async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      # YOUR CODE HERE
-
-
-asyncio.get_event_loop().run_until_complete(main())
-```
-
 To get all SimpliSafe™ systems associated with an account:
 
 ```python
 import asyncio
 
-from aiohttp import ClientSession
+from simplipy import API
+
+
+async def main() -> None:
+    """Create a client and get all of its systems."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    # >>> [<simplipy.system.SystemV2 object at 0x10661e3c8>, ...]
+
+
+asyncio.get_event_loop().run_until_complete(main())
+```
+
+If you have an existing `aiohttp.ClientSession`, you can use it:
+
+```python
+import asyncio
+
+from aiohttp import ClientSessions
 
 from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
+    """Create a client and get all of its systems."""
+    async with ClientSession() as session:
+      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", session)
       systems = await simplisafe.get_systems()
       # >>> [<simplipy.system.SystemV2 object at 0x10661e3c8>, ...]
 
 
 asyncio.get_event_loop().run_until_complete(main())
 ```
+
 
 ## The `System` Object
 
@@ -130,63 +131,62 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
-      systems = await simplisafe.get_systems()
-      # >>> [<simplipy.system.SystemV2 object at 0x10661e3c8>]
+    """Rock and roll."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    # >>> [<simplipy.system.SystemV2 object at 0x10661e3c8>]
 
-      for system in systems:
-        # Return a reference to a SimpliSafe™ API object (detailed later):
-        system.api
-        # >>> <simplipy.api.API object at 0x12aba2321>
+    for system in systems:
+      # Return a reference to a SimpliSafe™ API object (detailed later):
+      system.api
+      # >>> <simplipy.api.API object at 0x12aba2321>
 
-        # Return the street address of the system:
-        system.address
-        # >>> 1234 Main Street
+      # Return the street address of the system:
+      system.address
+      # >>> 1234 Main Street
 
-        # Return whether the alarm is currently going off:
-        system.alarm_going_off
-        # >>> False
+      # Return whether the alarm is currently going off:
+      system.alarm_going_off
+      # >>> False
 
-        # Return a list of sensors attached to this sytem (detailed later):
-        system.sensors
-        # >>> [<simplipy.sensor.SensorV2 object at 0x10661e3c8>, ...]
+      # Return a list of sensors attached to this sytem (detailed later):
+      system.sensors
+      # >>> [<simplipy.sensor.SensorV2 object at 0x10661e3c8>, ...]
 
-        # Return the system's serial number:
-        system.serial
-        # >>> 1234ABCD
+      # Return the system's serial number:
+      system.serial
+      # >>> 1234ABCD
 
-        # Return the current state of the system:
-        system.state
-        # >>> simplipy.system.SystemStates.away
+      # Return the current state of the system:
+      system.state
+      # >>> simplipy.system.SystemStates.away
 
-        # Return the SimpliSafe™ identifier for this system:
-        system.system_id
-        # >>> 1234ABCD
+      # Return the SimpliSafe™ identifier for this system:
+      system.system_id
+      # >>> 1234ABCD
 
-        # Return the average of all temperature sensors (if they exist):
-        system.temperature
-        # >>> 67
+      # Return the average of all temperature sensors (if they exist):
+      system.temperature
+      # >>> 67
 
-        # Return the SimpliSafe™ version:
-        system.version
-        # >>> 2
+      # Return the SimpliSafe™ version:
+      system.version
+      # >>> 2
 
-        # Return a list of events for the system with an optional start timestamp and
-        # number of events - omitting these parameters will return all events (max of
-        # 50) stored in SimpliSafe™'s cloud:
-        await system.get_events(from_timestamp=1534035861, num_events=2)
-        # >>> return {"numEvents": 2, "lastEventTimestamp": 1534035861, "events": [{...}]}
+      # Return a list of events for the system with an optional start timestamp and
+      # number of events - omitting these parameters will return all events (max of
+      # 50) stored in SimpliSafe™'s cloud:
+      await system.get_events(from_timestamp=1534035861, num_events=2)
+      # >>> return {"numEvents": 2, "lastEventTimestamp": 1534035861, "events": [{...}]}
 
-        # Set the state of the system:
-        await system.set_away()
-        await system.set_home()
-        await system.set_off()
+      # Set the state of the system:
+      await system.set_away()
+      await system.set_home()
+      await system.set_off()
 
-        # Get the latest values from the system; by default, include a refresh
-        # of system info and use cached values (both can be overridden):
-        await system.update(refresh_location=True, cached=True)
+      # Get the latest values from the system; by default, include a refresh
+      # of system info and use cached values (both can be overridden):
+      await system.update(refresh_location=True, cached=True)
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -229,39 +229,38 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
-      systems = await simplisafe.get_systems()
-      for system in systems:
-        for serial, sensor_attrs in system.sensors.items():
-          # Return the sensor's name:
-          sensor.name
-          # >>> Kitchen Window
+    """Rock and roll."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    for system in systems:
+      for serial, sensor_attrs in system.sensors.items():
+        # Return the sensor's name:
+        sensor.name
+        # >>> Kitchen Window
 
-          # Return the sensor's serial number through the index:
-          serial
-          # >>> 1234ABCD
+        # Return the sensor's serial number through the index:
+        serial
+        # >>> 1234ABCD
 
-          # ...or through the property:
-          sensor.serial
-          # >>> 1234ABCD
+        # ...or through the property:
+        sensor.serial
+        # >>> 1234ABCD
 
-          # Return the sensor's type:
-          sensor.type
-          # >>> simplipy.sensor.SensorTypes.glass_break
+        # Return the sensor's type:
+        sensor.type
+        # >>> simplipy.sensor.SensorTypes.glass_break
 
-          # Return whether the sensor is in an error state:
-          sensor.error
-          # >>> False
+        # Return whether the sensor is in an error state:
+        sensor.error
+        # >>> False
 
-          # Return whether the sensor has a low battery:
-          sensor.low_battery
-          # >>> False
+        # Return whether the sensor has a low battery:
+        sensor.low_battery
+        # >>> False
 
-          # Return whether the sensor has been triggered (open/closed, etc.):
-          sensor.triggered
-          # >>> False
+        # Return whether the sensor has been triggered (open/closed, etc.):
+        sensor.triggered
+        # >>> False
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -274,19 +273,18 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
-      systems = await simplisafe.get_systems()
-      for system in systems:
-        for serial, sensor_attrs in system.sensors.items():
-          # Return the sensor's data as a currently non-understood integer:
-          sensor.data
-          # >>> 0
+    """Rock and roll."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    for system in systems:
+      for serial, sensor_attrs in system.sensors.items():
+        # Return the sensor's data as a currently non-understood integer:
+        sensor.data
+        # >>> 0
 
-          # Return the sensor's settings as a currently non-understood integer:
-          sensor.settings
-          # >>> 1
+        # Return the sensor's settings as a currently non-understood integer:
+        sensor.settings
+        # >>> 1
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -299,23 +297,22 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
-      systems = await simplisafe.get_systems()
-      for system in systems:
-        for sensor in system.sensors:
-          # Return whether the sensor is offline:
-          sensor.offline
-          # >>> False
+    """Rock and roll."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    for system in systems:
+      for sensor in system.sensors:
+        # Return whether the sensor is offline:
+        sensor.offline
+        # >>> False
 
-          # Return a settings dictionary for the sensor:
-          sensor.settings
-          # >>> {"instantTrigger": False, "away2": 1, "away": 1, ...}
+        # Return a settings dictionary for the sensor:
+        sensor.settings
+        # >>> {"instantTrigger": False, "away2": 1, "away": 1, ...}
 
-          # For temperature sensors, return the current temperature:
-          sensor.temperature
-          # >>> 67
+        # For temperature sensors, return the current temperature:
+        sensor.temperature
+        # >>> 67
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -337,22 +334,21 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>", websession)
-      systems = await simplisafe.get_systems()
-      for system in systems:
-        # Return the current access token:
-        system.api._access_token
-        # >>> 7s9yasdh9aeu21211add
+    """Rock and roll."""
+    simplisafe = API.login_via_credentials("<EMAIL>", "<PASSWORD>")
+    systems = await simplisafe.get_systems()
+    for system in systems:
+      # Return the current access token:
+      system.api._access_token
+      # >>> 7s9yasdh9aeu21211add
 
-        # Return the current refresh token:
-        system.api.refresh_token
-        # >>> 896sad86gudas87d6asd
+      # Return the current refresh token:
+      system.api.refresh_token
+      # >>> 896sad86gudas87d6asd
 
-        # Return the SimpliSafe™ user ID associated with this account:
-        system.api.user_id
-        # >>> 1234567
+      # Return the SimpliSafe™ user ID associated with this account:
+      system.api.user_id
+      # >>> 1234567
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -381,19 +377,18 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_token("<REFRESH TOKEN>", websession)
-      systems = await simplisafe.get_systems()
-      primary_system = systems[0]
+    """Rock and roll."""
+    simplisafe = API.login_via_token("<REFRESH TOKEN>")
+    systems = await simplisafe.get_systems()
+    primary_system = systems[0]
 
-      # Assuming the access token was automatically refreshed:
-      primary_system.api.refresh_token_dirty
-      # >>> True
+    # Assuming the access token was automatically refreshed:
+    primary_system.api.refresh_token_dirty
+    # >>> True
 
-      # Once the dirtiness is confirmed, the dirty bit resets:
-      primary_system.api.refresh_token_dirty
-      # >>> False
+    # Once the dirtiness is confirmed, the dirty bit resets:
+    primary_system.api.refresh_token_dirty
+    # >>> False
 
 
 asyncio.get_event_loop().run_until_complete(main())
@@ -411,11 +406,10 @@ from simplipy import API
 
 
 async def main() -> None:
-    """Create the aiohttp session and run."""
-    async with ClientSession() as websession:
-      simplisafe = API.login_via_token("<REFRESH TOKEN>", websession)
-      systems = await simplisafe.get_systems()
-      # ...
+    """Rock and roll."""
+    simplisafe = API.login_via_token("<REFRESH TOKEN>")
+    systems = await simplisafe.get_systems()
+    # ...
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/example.py
+++ b/example.py
@@ -4,55 +4,44 @@
 import asyncio
 import logging
 
-from aiohttp import ClientSession
-
 from simplipy import API
 from simplipy.errors import InvalidCredentialsError, SimplipyError
 
 _LOGGER = logging.getLogger()
 
 
-async def exercise_client(
-        email: str, password: str, websession: ClientSession) -> None:
-    """Test a SimpliSafe client (regardless of version)."""
-    _LOGGER.info('Testing account email: %s', email)
-
-    simplisafe = await API.login_via_credentials(email, password, websession)
-    systems = await simplisafe.get_systems()
-    for idx, system in enumerate(systems):
-        _LOGGER.info('System #%s', idx + 1)
-        _LOGGER.info('Version: %s', system.version)
-        _LOGGER.info('User ID: %s', system.api.user_id)
-        _LOGGER.info('Access Token: %s', system.api._access_token)
-        _LOGGER.info('Refresh Token: %s', system.api.refresh_token)
-
-        events = await system.get_events()
-        _LOGGER.info('Number of Events: %s', len(events))
-
-        for serial, sensor_attrs in system.sensors.items():
-            _LOGGER.info(
-                'Info for sensor %s: (name: %s, type: %s, triggered: %s)',
-                serial, sensor_attrs.name, sensor_attrs.type,
-                sensor_attrs.triggered)
-
-        _LOGGER.info('Setting System to "Home":')
-        await system.set_home()
-
-        _LOGGER.info('Setting System to "Off":')
-        await system.set_off()
-
-
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
-        logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.INFO)
 
-        try:
-            await exercise_client('<EMAIL>', '<PASSWORD>', websession)
-        except InvalidCredentialsError:
-            _LOGGER.error('Invalid credentials')
-        except SimplipyError as err:
-            _LOGGER.error(err)
+    try:
+        simplisafe = await API.login_via_credentials('<EMAIL>', '<PASSWORD>')
+        systems = await simplisafe.get_systems()
+        for idx, system in enumerate(systems):
+            _LOGGER.info('System #%s', idx + 1)
+            _LOGGER.info('Version: %s', system.version)
+            _LOGGER.info('User ID: %s', system.api.user_id)
+            _LOGGER.info('Access Token: %s', system.api._access_token)
+            _LOGGER.info('Refresh Token: %s', system.api.refresh_token)
+
+            events = await system.get_events()
+            _LOGGER.info('Number of Events: %s', len(events))
+
+            for serial, sensor_attrs in system.sensors.items():
+                _LOGGER.info(
+                    'Info for sensor %s: (name: %s, type: %s, triggered: %s)',
+                    serial, sensor_attrs.name, sensor_attrs.type,
+                    sensor_attrs.triggered)
+
+            _LOGGER.info('Setting System to "Home":')
+            await system.set_home()
+
+            _LOGGER.info('Setting System to "Off":')
+            await system.set_off()
+    except InvalidCredentialsError:
+        _LOGGER.error('Invalid credentials')
+    except SimplipyError as err:
+        _LOGGER.error(err)
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,6 @@ import json
 import logging
 from datetime import datetime, timedelta
 
-import aiohttp
 import aresponses
 import pytest
 
@@ -20,24 +19,22 @@ from .fixtures.v3 import *  # noqa
 
 
 @pytest.mark.asyncio
-async def test_bad_request(event_loop, v2_server):
+async def test_bad_request(v2_server):
     """Test that a generic error is thrown when a request fails."""
     async with v2_server:
         v2_server.add(
             'api.simplisafe.com', '/v1/api/fakeEndpoint', 'get',
             aresponses.Response(text='', status=404))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
-            with pytest.raises(RequestError):
-                await system.api.request('get', 'api/fakeEndpoint')
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
+        with pytest.raises(RequestError):
+            await system.api.request('get', 'api/fakeEndpoint')
 
 
 @pytest.mark.asyncio
 async def test_expired_token_refresh(
-        api_token_json, auth_check_json, event_loop, v2_server):
+        api_token_json, auth_check_json, v2_server):
     """Test that a refresh token is used correctly."""
     async with v2_server:
         v2_server.add(
@@ -50,13 +47,10 @@ async def test_expired_token_refresh(
             'api.simplisafe.com', '/v1/api/authCheck', 'get',
             aresponses.Response(text=json.dumps(auth_check_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
-            system.api._access_token_expire = datetime.now() - timedelta(
-                hours=1)
-            await system.api.request('get', 'api/authCheck')
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
+        system.api._access_token_expire = datetime.now() - timedelta(hours=1)
+        await system.api.request('get', 'api/authCheck')
 
 
 @pytest.mark.asyncio
@@ -69,15 +63,13 @@ async def test_invalid_credentials(
             aresponses.Response(
                 text=json.dumps(invalid_credentials_json), status=403))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            with pytest.raises(InvalidCredentialsError):
-                await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession)
+        with pytest.raises(InvalidCredentialsError):
+            await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
 
 
 @pytest.mark.asyncio
 async def test_refresh_token_dirtiness(
-        api_token_json, auth_check_json, event_loop, v2_server):
+        api_token_json, auth_check_json, v2_server):
     """Test that the refresh token's dirtiness can be checked."""
     async with v2_server:
         v2_server.add(
@@ -90,22 +82,20 @@ async def test_refresh_token_dirtiness(
             'api.simplisafe.com', '/v1/api/authCheck', 'get',
             aresponses.Response(text=json.dumps(auth_check_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
-            system.api._access_token_expire = datetime.now() - timedelta(
-                hours=1)
-            await system.api.request('get', 'api/authCheck')
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
+        system.api._access_token_expire = datetime.now() - timedelta(
+            hours=1)
+        await system.api.request('get', 'api/authCheck')
 
-            assert system.api.refresh_token_dirty
-            assert system.api.refresh_token == TEST_REFRESH_TOKEN
-            assert not system.api.refresh_token_dirty
+        assert system.api.refresh_token_dirty
+        assert system.api.refresh_token == TEST_REFRESH_TOKEN
+        assert not system.api.refresh_token_dirty
 
 
 @pytest.mark.asyncio
 async def test_unavailable_feature_v2(
-        api_token_json, auth_check_json, caplog, event_loop, v2_server,
+        api_token_json, auth_check_json, caplog, v2_server,
         v2_subscriptions_json, unavailable_feature_json):
     """Test that a message is logged with an unavailable feature."""
     caplog.set_level(logging.INFO)
@@ -134,23 +124,21 @@ async def test_unavailable_feature_v2(
             aresponses.Response(
                 text=json.dumps(unavailable_feature_json), status=403))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
-            await system.update()
-            await system.set_away()
-            logs = [
-                l for l in
-                ['not available' in e.message for e in caplog.records]
-                if l is not False
-            ]
-            assert len(logs) == 2
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
+        await system.update()
+        await system.set_away()
+        logs = [
+            l for l in
+            ['not available' in e.message for e in caplog.records]
+            if l is not False
+        ]
+        assert len(logs) == 2
 
 
 @pytest.mark.asyncio
 async def test_unavailable_feature_v3(
-        api_token_json, auth_check_json, caplog, event_loop, v3_server,
+        api_token_json, auth_check_json, caplog, v3_server,
         v3_subscriptions_json, unavailable_feature_json):
     """Test that a message is logged with an unavailable feature."""
     caplog.set_level(logging.INFO)
@@ -179,15 +167,13 @@ async def test_unavailable_feature_v3(
             aresponses.Response(
                 text=json.dumps(unavailable_feature_json), status=403))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
-            await system.update()
-            await system.set_away()
-            logs = [
-                l for l in
-                ['not available' in e.message for e in caplog.records]
-                if l is not False
-            ]
-            assert len(logs) == 2
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
+        await system.update()
+        await system.set_away()
+        logs = [
+            l for l in
+            ['not available' in e.message for e in caplog.records]
+            if l is not False
+        ]
+        assert len(logs) == 2

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,7 +1,6 @@
 """Define tests for the Sensor objects."""
 # pylint: disable=protected-access,redefined-outer-name
 
-import aiohttp
 import pytest
 
 from simplipy import API
@@ -15,84 +14,76 @@ from .fixtures.v3 import *
 
 
 @pytest.mark.asyncio
-async def test_properties_base(event_loop, v2_server):
+async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            sensor = system.sensors['195']
-            assert sensor.name == 'Garage Keypad'
-            assert sensor.serial == '195'
-            assert sensor.type == SensorTypes.keypad
+        sensor = system.sensors['195']
+        assert sensor.name == 'Garage Keypad'
+        assert sensor.serial == '195'
+        assert sensor.type == SensorTypes.keypad
 
 
 @pytest.mark.asyncio
-async def test_properties_v2(event_loop, v2_server):
+async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            keypad = system.sensors['195']
-            assert keypad.data == 0
-            assert not keypad.error
-            assert not keypad.low_battery
-            assert keypad.settings == 1
+        keypad = system.sensors['195']
+        assert keypad.data == 0
+        assert not keypad.error
+        assert not keypad.low_battery
+        assert keypad.settings == 1
 
-            # Ensure that attempting to access the triggered of anything but
-            # an entry sensor in a V2 system throws an error:
-            with pytest.raises(SimplipyError):
-                assert keypad.triggered == 42
+        # Ensure that attempting to access the triggered of anything but
+        # an entry sensor in a V2 system throws an error:
+        with pytest.raises(SimplipyError):
+            assert keypad.triggered == 42
 
-            entry_sensor = system.sensors['609']
-            assert entry_sensor.data == 130
-            assert not entry_sensor.error
-            assert not entry_sensor.low_battery
-            assert entry_sensor.settings == 1
-            assert not entry_sensor.trigger_instantly
-            assert not entry_sensor.triggered
+        entry_sensor = system.sensors['609']
+        assert entry_sensor.data == 130
+        assert not entry_sensor.error
+        assert not entry_sensor.low_battery
+        assert entry_sensor.settings == 1
+        assert not entry_sensor.trigger_instantly
+        assert not entry_sensor.triggered
 
 
 @pytest.mark.asyncio
-async def test_properties_v3(event_loop, v3_server):
+async def test_properties_v3(v3_server):
     """Test that v3 sensor properties are created properly."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            entry_sensor = system.sensors['825']
-            assert not entry_sensor.error
-            assert not entry_sensor.low_battery
-            assert not entry_sensor.offline
-            assert not entry_sensor.settings['instantTrigger']
-            assert not entry_sensor.trigger_instantly
-            assert not entry_sensor.triggered
+        entry_sensor = system.sensors['825']
+        assert not entry_sensor.error
+        assert not entry_sensor.low_battery
+        assert not entry_sensor.offline
+        assert not entry_sensor.settings['instantTrigger']
+        assert not entry_sensor.trigger_instantly
+        assert not entry_sensor.triggered
 
-            siren = system.sensors['236']
-            assert not siren.triggered
+        siren = system.sensors['236']
+        assert not siren.triggered
 
-            temperature_sensor = system.sensors['320']
-            assert temperature_sensor.temperature == 67
+        temperature_sensor = system.sensors['320']
+        assert temperature_sensor.temperature == 67
 
-            # Ensure that attempting to access the temperature attribute of a
-            # non-temperature sensor throws an error:
-            with pytest.raises(AttributeError):
-                assert siren.temperature == 42
+        # Ensure that attempting to access the temperature attribute of a
+        # non-temperature sensor throws an error:
+        with pytest.raises(AttributeError):
+            assert siren.temperature == 42
 
 
 @pytest.mark.asyncio
-async def test_unknown_sensor_type(caplog, event_loop, v2_server):
+async def test_unknown_sensor_type(caplog, v2_server):
     """Test that a message is logged when unknown sensors types are found."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            _ = await api.get_systems()  # noqa
-            assert any('Unknown' in e.message for e in caplog.records)
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        _ = await api.get_systems()  # noqa
+        assert any('Unknown' in e.message for e in caplog.records)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -3,7 +3,6 @@
 
 import json
 
-import aiohttp
 import aresponses
 import pytest
 
@@ -20,7 +19,7 @@ from .fixtures.v3 import *  # noqa
 
 
 @pytest.mark.asyncio
-async def test_get_events(events_json, event_loop, v2_server):
+async def test_get_events(events_json, v2_server):
     """Test getting events from a system."""
     async with v2_server:
         v2_server.add(
@@ -28,20 +27,18 @@ async def test_get_events(events_json, event_loop, v2_server):
             '/v1/subscriptions/{0}/events'.format(TEST_SYSTEM_ID), 'get',
             aresponses.Response(text=json.dumps(events_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            events = await system.get_events(1534725051, 2)
+        events = await system.get_events(1534725051, 2)
 
-            assert len(events) == 2
+        assert len(events) == 2
 
 
 @pytest.mark.asyncio
 async def test_get_systems_v2(
-        api_token_json, auth_check_json, event_loop, v2_server,
-        v2_settings_json, v2_subscriptions_json):
+        api_token_json, auth_check_json, v2_server, v2_settings_json,
+        v2_subscriptions_json):
     """Test the ability to get systems attached to a v2 account."""
     async with v2_server:
         # Since this flow will call both three routes once more each (on top of
@@ -64,38 +61,36 @@ async def test_get_systems_v2(
             'get',
             aresponses.Response(text=json.dumps(v2_settings_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            credentials_api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            systems = await credentials_api.get_systems()
+        credentials_api = await API.login_via_credentials(
+            TEST_EMAIL, TEST_PASSWORD)
+        systems = await credentials_api.get_systems()
 
-            assert len(systems) == 1
+        assert len(systems) == 1
 
-            primary_system = systems[0]
+        primary_system = systems[0]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 35
+        assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
+        assert primary_system.system_id == TEST_SYSTEM_ID
+        assert primary_system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(primary_system.sensors) == 35
 
-            token_api = await API.login_via_token(
-                TEST_REFRESH_TOKEN, websession)
-            systems = await token_api.get_systems()
+        token_api = await API.login_via_token(TEST_REFRESH_TOKEN)
+        systems = await token_api.get_systems()
 
-            assert len(systems) == 1
+        assert len(systems) == 1
 
-            primary_system = systems[0]
+        primary_system = systems[0]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 35
+        assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
+        assert primary_system.system_id == TEST_SYSTEM_ID
+        assert primary_system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(primary_system.sensors) == 35
 
 
 @pytest.mark.asyncio
 async def test_get_systems_v3(
-        api_token_json, auth_check_json, event_loop, v3_server,
-        v3_sensors_json, v3_subscriptions_json):
+        api_token_json, auth_check_json, v3_server, v3_sensors_json,
+        v3_subscriptions_json):
     """Test the ability to get systems attached to a v3 account."""
     async with v3_server:
         # Since this flow will call both three routes once more each (on top of
@@ -118,56 +113,51 @@ async def test_get_systems_v3(
             'get',
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            credentials_api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            systems = await credentials_api.get_systems()
+        credentials_api = await API.login_via_credentials(
+            TEST_EMAIL, TEST_PASSWORD)
+        systems = await credentials_api.get_systems()
 
-            assert len(systems) == 1
+        assert len(systems) == 1
 
-            primary_system = systems[0]
+        primary_system = systems[0]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 21
+        assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
+        assert primary_system.system_id == TEST_SYSTEM_ID
+        assert primary_system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(primary_system.sensors) == 21
 
-            token_api = await API.login_via_token(
-                TEST_REFRESH_TOKEN, websession)
-            systems = await token_api.get_systems()
+        token_api = await API.login_via_token(TEST_REFRESH_TOKEN)
+        systems = await token_api.get_systems()
 
-            assert len(systems) == 1
+        assert len(systems) == 1
 
-            primary_system = systems[0]
+        primary_system = systems[0]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 21
+        assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
+        assert primary_system.system_id == TEST_SYSTEM_ID
+        assert primary_system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(primary_system.sensors) == 21
 
 
 @pytest.mark.asyncio
-async def test_properties_base(event_loop, v2_server):
+async def test_properties_base(v2_server):
     """Test that base system properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            assert system.address == TEST_ADDRESS
-            assert not system.alarm_going_off
-            assert system.serial == TEST_SYSTEM_SERIAL_NO
-            assert system.state == SystemStates.off
-            assert system.system_id == TEST_SYSTEM_ID
-            assert system.temperature == 67
-            assert system.version == 2
+        assert system.address == TEST_ADDRESS
+        assert not system.alarm_going_off
+        assert system.serial == TEST_SYSTEM_SERIAL_NO
+        assert system.state == SystemStates.off
+        assert system.system_id == TEST_SYSTEM_ID
+        assert system.temperature == 67
+        assert system.version == 2
 
 
 @pytest.mark.asyncio
 async def test_set_states_v2(
-        event_loop, v2_server, v2_state_away_json, v2_state_home_json,
-        v2_state_off_json):
+        v2_server, v2_state_away_json, v2_state_home_json, v2_state_off_json):
     """Test the ability to set the state of a v2 system."""
     async with v2_server:
         # Since this flow will make the same API call four times and
@@ -194,32 +184,25 @@ async def test_set_states_v2(
             aresponses.Response(
                 text=json.dumps(v2_state_off_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            await system.set_away()
+        await system.set_away()
+        assert system.state == SystemStates.away
 
-            assert system.state == SystemStates.away
+        await system.set_home()
+        assert system.state == SystemStates.home
 
-            await system.set_home()
+        await system.set_off()
+        assert system.state == SystemStates.off
 
-            assert system.state == SystemStates.home
-
-            await system.set_off()
-
-            assert system.state == SystemStates.off
-
-            await system.set_off()
-
-            assert system.state == SystemStates.off
+        await system.set_off()
+        assert system.state == SystemStates.off
 
 
 @pytest.mark.asyncio
 async def test_set_states_v3(
-        event_loop, v3_server, v3_state_away_json, v3_state_home_json,
-        v3_state_off_json):
+        v3_server, v3_state_away_json, v3_state_home_json, v3_state_off_json):
     """Test the ability to set the state of the system."""
     async with v3_server:
         # Since this flow will make the same API call four times and
@@ -246,55 +229,43 @@ async def test_set_states_v3(
             aresponses.Response(
                 text=json.dumps(v3_state_off_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            await system.set_away()
+        await system.set_away()
+        assert system.state == SystemStates.away
 
-            assert system.state == SystemStates.away
+        await system.set_home()
+        assert system.state == SystemStates.home
 
-            await system.set_home()
+        await system.set_off()
+        assert system.state == SystemStates.off
 
-            assert system.state == SystemStates.home
-
-            await system.set_off()
-
-            assert system.state == SystemStates.off
-
-            await system.set_off()
-
-            assert system.state == SystemStates.off
+        await system.set_off()
+        assert system.state == SystemStates.off
 
 
 @pytest.mark.asyncio
-async def test_unknown_initial_state(caplog, event_loop):
+async def test_unknown_initial_state(caplog):
     """Test handling of an initially unknown state."""
-    async with aiohttp.ClientSession(loop=event_loop) as websession:
-        _ = System(  # noqa
-            API(websession), {'system': {
-                'alarmState': 'fake'
-            }})
+    _ = System(API(), {'system': {'alarmState': 'fake'}})  # noqa
+
+    assert any('Unknown' in e.message for e in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_unknown_sensor_type(caplog, v2_server):
+    """Test whether a message is logged upon finding an unknown sensor type."""
+    async with v2_server:
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        _ = await api.get_systems()  # noqa
 
         assert any('Unknown' in e.message for e in caplog.records)
 
 
 @pytest.mark.asyncio
-async def test_unknown_sensor_type(caplog, event_loop, v2_server):
-    """Test whether a message is logged upon finding an unknown sensor type."""
-    async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            _ = await api.get_systems()  # noqa
-
-            assert any('Unknown' in e.message for e in caplog.records)
-
-
-@pytest.mark.asyncio
 async def test_update_system_data_v2(
-        event_loop, v2_server, v2_settings_json, v2_subscriptions_json):
+        v2_server, v2_settings_json, v2_subscriptions_json):
     """Test getting updated data for a v2 system."""
     async with v2_server:
         v2_server.add(
@@ -308,22 +279,20 @@ async def test_update_system_data_v2(
             'get',
             aresponses.Response(text=json.dumps(v2_settings_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            await system.update()
+        await system.update()
 
-            assert system.serial == TEST_SYSTEM_SERIAL_NO
-            assert system.system_id == TEST_SYSTEM_ID
-            assert system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(system.sensors) == 35
+        assert system.serial == TEST_SYSTEM_SERIAL_NO
+        assert system.system_id == TEST_SYSTEM_ID
+        assert system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(system.sensors) == 35
 
 
 @pytest.mark.asyncio
 async def test_update_system_data_v3(
-        event_loop, v3_server, v3_sensors_json, v3_subscriptions_json):
+        v3_server, v3_sensors_json, v3_subscriptions_json):
     """Test getting updated data for a v3 system."""
     async with v3_server:
         v3_server.add(
@@ -337,14 +306,12 @@ async def test_update_system_data_v3(
             'get',
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200))
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+        api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        [system] = await api.get_systems()
 
-            await system.update()
+        await system.update()
 
-            assert system.serial == TEST_SYSTEM_SERIAL_NO
-            assert system.system_id == TEST_SYSTEM_ID
-            assert system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(system.sensors) == 21
+        assert system.serial == TEST_SYSTEM_SERIAL_NO
+        assert system.system_id == TEST_SYSTEM_ID
+        assert system.api._access_token == TEST_ACCESS_TOKEN
+        assert len(system.sensors) == 21


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes the requirement of passing an `aiohttp.ClientSession` into the Client; that is now optional.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
