### PR TITLE
Attempt refresh token upon initial 401

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -175,10 +175,10 @@ class API:
         except ClientError as err:
             if '401' in str(err):
                 if self._actively_refreshing:
-                    _LOGGER.error('Refresh token was unsuccessful')
+                    _LOGGER.error('Refresh token was unsuccessful on 401')
                     raise InvalidCredentialsError
                 if self._refresh_token:
-                    _LOGGER.info('401 detected; using refresh token')
+                    _LOGGER.info('401 detected; attempting refresh token')
                     self._access_token_expire = datetime.now()
                     return await self.request(
                         method,

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -179,9 +179,15 @@ class API:
                     raise InvalidCredentialsError
                 if self._refresh_token:
                     _LOGGER.info('401 detected; using refresh token')
-                    self._actively_refreshing = True
-                    await self._refresh_access_token(self._refresh_token)
-                    return {}
+                    self._access_token_expire = datetime.now()
+                    return await self.request(
+                        method,
+                        endpoint,
+                        headers=headers,
+                        params=params,
+                        data=data,
+                        json=json,
+                        **kwargs)
                 raise InvalidCredentialsError
             if '403' in str(err):
                 if self.user_id:


### PR DESCRIPTION
**Describe what the PR does:**

It appears that every so often, SimpliSafe will invalidate an access token before its expiration time – who knows why. In that case, the user will continue to see `401` responses until that expiration time. This PR will attempt to refresh the access token upon seeing a `401` for the first time; if refreshing is unsuccessful and another `401` is seen, an `InvalidCredentialsError` exception is thrown.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)