### PR TITLE
Make get_systems return a dict instead of a list

### DIFF
--- a/example.py
+++ b/example.py
@@ -25,8 +25,8 @@ async def main() -> None:
                 SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
             )
             systems = await simplisafe.get_systems()
-            for idx, system in enumerate(systems):
-                _LOGGER.info("System #%s", idx + 1)
+            for system_id, system in systems.items():
+                _LOGGER.info("System ID: %s", system_id)
                 _LOGGER.info("Version: %s", system.version)
                 _LOGGER.info("User ID: %s", system.api.user_id)
                 _LOGGER.info("Access Token: %s", system.api._access_token)

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -3,7 +3,7 @@
 
 import logging
 from datetime import datetime, timedelta
-from typing import List, Optional, Type, TypeVar
+from typing import Dict, Optional, Type, TypeVar
 from uuid import uuid4
 
 from aiohttp import BasicAuth, ClientSession
@@ -114,17 +114,17 @@ class API:
 
         self._actively_refreshing = False
 
-    async def get_systems(self) -> list:
+    async def get_systems(self) -> Dict[str, System]:
         """Get systems associated to this account."""
         subscription_resp = await self.get_subscription_data()
 
-        systems = []  # type: List[System]
+        systems = {}
         for system_data in subscription_resp["subscriptions"]:
             version = system_data["location"]["system"]["version"]
             system_class = SYSTEM_MAP[version]
             system = system_class(self, system_data["location"])
             await system.update(refresh_location=False)
-            systems.append(system)
+            systems[system_data["sid"]] = system
 
         return systems
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ from .const import (
     TEST_PASSWORD,
     TEST_REFRESH_TOKEN,
     TEST_SUBSCRIPTION_ID,
+    TEST_SYSTEM_ID,
     TEST_USER_ID,
 )
 from .fixtures import *  # noqa
@@ -68,7 +69,9 @@ async def test_401_refresh_token_failure(
                 api = await API.login_via_credentials(
                     TEST_EMAIL, TEST_PASSWORD, websession
                 )
-                [system] = await api.get_systems()
+
+                systems = await api.get_systems()
+                system = systems[TEST_SYSTEM_ID]
                 await system.update()
 
 
@@ -116,7 +119,8 @@ async def test_401_refresh_token_success(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             await system.update()
 
             assert system.api.refresh_token_dirty
@@ -137,7 +141,8 @@ async def test_bad_request(event_loop, v2_server):
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             with pytest.raises(RequestError):
                 await system.api.request("get", "api/fakeEndpoint")
 
@@ -169,7 +174,8 @@ async def test_expired_token_refresh(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             system.api._access_token_expire = datetime.now() - timedelta(hours=1)
             await system.api.request("get", "api/authCheck")
 
@@ -217,7 +223,8 @@ async def test_refresh_token_dirtiness(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             system.api._access_token_expire = datetime.now() - timedelta(hours=1)
             await system.api.request("get", "api/authCheck")
 
@@ -273,7 +280,8 @@ async def test_unavailable_feature_v2(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             await system.update()
             await system.set_away()
             logs = [
@@ -281,6 +289,7 @@ async def test_unavailable_feature_v2(
                 for l in ["unavailable in plan" in e.message for e in caplog.records]
                 if l is not False
             ]
+
             assert len(logs) == 2
 
 
@@ -338,7 +347,8 @@ async def test_unavailable_feature_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
             await system.update()
             await system.set_away()
             logs = [
@@ -346,4 +356,5 @@ async def test_unavailable_feature_v3(
                 for l in ["unavailable in plan" in e.message for e in caplog.records]
                 if l is not False
             ]
+
             assert len(logs) == 2

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -8,7 +8,7 @@ from simplipy import API
 from simplipy.errors import SimplipyError
 from simplipy.sensor import SensorTypes
 
-from .const import TEST_EMAIL, TEST_PASSWORD
+from .const import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 from .fixtures import *
 from .fixtures.v2 import *
 from .fixtures.v3 import *
@@ -20,7 +20,8 @@ async def test_properties_base(event_loop, v2_server):
     async with v2_server:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             sensor = system.sensors["195"]
             assert sensor.name == "Garage Keypad"
@@ -34,7 +35,8 @@ async def test_properties_v2(event_loop, v2_server):
     async with v2_server:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             keypad = system.sensors["195"]
             assert keypad.data == 0
@@ -62,7 +64,8 @@ async def test_properties_v3(event_loop, v3_server):
     async with v3_server:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             entry_sensor = system.sensors["825"]
             assert not entry_sensor.error

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -40,7 +40,8 @@ async def test_get_events(events_json, event_loop, v2_server):
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             events = await system.get_events(1534725051, 2)
 
@@ -60,7 +61,8 @@ async def test_get_pins_v2(event_loop, v2_pins_json, v2_server):
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             pins = await system.get_pins()
             assert len(pins) == 4
@@ -83,7 +85,8 @@ async def test_get_pins_v3(event_loop, v3_server, v3_settings_json):
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             pins = await system.get_pins()
             assert len(pins) == 4
@@ -137,27 +140,23 @@ async def test_get_systems_v2(
                 TEST_EMAIL, TEST_PASSWORD, websession
             )
             systems = await credentials_api.get_systems()
-
             assert len(systems) == 1
 
-            primary_system = systems[0]
-
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 35
+            system = systems[TEST_SYSTEM_ID]
+            assert system.serial == TEST_SYSTEM_SERIAL_NO
+            assert system.system_id == TEST_SYSTEM_ID
+            assert system.api._access_token == TEST_ACCESS_TOKEN
+            assert len(system.sensors) == 35
 
             token_api = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
             systems = await token_api.get_systems()
-
             assert len(systems) == 1
 
-            primary_system = systems[0]
-
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 35
+            system = systems[TEST_SYSTEM_ID]
+            assert system.serial == TEST_SYSTEM_SERIAL_NO
+            assert system.system_id == TEST_SYSTEM_ID
+            assert system.api._access_token == TEST_ACCESS_TOKEN
+            assert len(system.sensors) == 35
 
 
 @pytest.mark.asyncio
@@ -211,27 +210,25 @@ async def test_get_systems_v3(
                 TEST_EMAIL, TEST_PASSWORD, websession
             )
             systems = await credentials_api.get_systems()
-
             assert len(systems) == 1
 
-            primary_system = systems[0]
+            system = systems[TEST_SYSTEM_ID]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 21
+            assert system.serial == TEST_SYSTEM_SERIAL_NO
+            assert system.system_id == TEST_SYSTEM_ID
+            assert system.api._access_token == TEST_ACCESS_TOKEN
+            assert len(system.sensors) == 21
 
             token_api = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
             systems = await token_api.get_systems()
-
             assert len(systems) == 1
 
-            primary_system = systems[0]
+            system = systems[TEST_SYSTEM_ID]
 
-            assert primary_system.serial == TEST_SYSTEM_SERIAL_NO
-            assert primary_system.system_id == TEST_SYSTEM_ID
-            assert primary_system.api._access_token == TEST_ACCESS_TOKEN
-            assert len(primary_system.sensors) == 21
+            assert system.serial == TEST_SYSTEM_SERIAL_NO
+            assert system.system_id == TEST_SYSTEM_ID
+            assert system.api._access_token == TEST_ACCESS_TOKEN
+            assert len(system.sensors) == 21
 
 
 @pytest.mark.asyncio
@@ -247,7 +244,8 @@ async def test_remove_nonexistent_pin_v3(event_loop, v3_server, v3_settings_json
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             with pytest.raises(PinError) as err:
                 await system.remove_pin("0000")
@@ -291,7 +289,8 @@ async def test_remove_pin_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             latest_pins = await system.get_pins()
             assert len(latest_pins) == 4
@@ -314,7 +313,8 @@ async def test_remove_reserved_pin_v3(event_loop, v3_server, v3_settings_json):
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             with pytest.raises(PinError) as err:
                 await system.remove_pin("master")
@@ -343,7 +343,8 @@ async def test_set_duplicate_pin(event_loop, v3_server, v3_settings_json):
                 api = await API.login_via_credentials(
                     TEST_EMAIL, TEST_PASSWORD, websession
                 )
-                [system] = await api.get_systems()
+                systems = await api.get_systems()
+                system = systems[TEST_SYSTEM_ID]
 
                 await system.set_pin("whatever", "1234")
                 assert "Refusing to create duplicate PIN" in str(err)
@@ -375,7 +376,8 @@ async def test_set_max_user_pins(
                 api = await API.login_via_credentials(
                     TEST_EMAIL, TEST_PASSWORD, websession
                 )
-                [system] = await api.get_systems()
+                systems = await api.get_systems()
+                system = systems[TEST_SYSTEM_ID]
 
                 await system.set_pin("whatever", "8121")
                 assert "Refusing to create more than" in str(err)
@@ -412,7 +414,8 @@ async def test_set_pins_v2(event_loop, v2_new_pins_json, v2_pins_json, v2_server
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             latest_pins = await system.get_pins()
             assert len(latest_pins) == 4
@@ -455,7 +458,8 @@ async def test_set_pin_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             latest_pins = await system.get_pins()
             assert len(latest_pins) == 4
@@ -471,7 +475,8 @@ async def test_properties(event_loop, v2_server):
     async with v2_server:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             assert system.address == TEST_ADDRESS
             assert not system.alarm_going_off
@@ -488,7 +493,8 @@ async def test_properties_v3(event_loop, v3_server):
     async with v3_server:
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             assert system.alarm_duration == 240
             assert system.alarm_volume == 3
@@ -542,22 +548,19 @@ async def test_set_states_v2(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             await system.set_away()
-
             assert system.state == SystemStates.away
 
             await system.set_home()
-
             assert system.state == SystemStates.home
 
             await system.set_off()
-
             assert system.state == SystemStates.off
 
             await system.set_off()
-
             assert system.state == SystemStates.off
 
 
@@ -597,7 +600,8 @@ async def test_set_states_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             await system.set_away()
             assert system.state == SystemStates.away
@@ -653,7 +657,8 @@ async def test_update_system_data_v2(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             await system.update()
 
@@ -690,7 +695,8 @@ async def test_update_system_data_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             await system.update()
 
@@ -732,7 +738,8 @@ async def test_update_error_v3(
 
         async with aiohttp.ClientSession(loop=event_loop) as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            [system] = await api.get_systems()
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
 
             await system.update()
 


### PR DESCRIPTION
**Describe what the PR does:**

Tradtionally, `api.get_systems()` returned a list of systems. There are several situations where it's preferable to lookup a particular system, instead; to make this fast, this PR changes the result of `api.get_systems()` to a dict with system ID as the key and `system` object as the value.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
