### PR TITLE
Fix edge cases when setting PINs

### DIFF
--- a/simplipy/system.py
+++ b/simplipy/system.py
@@ -14,6 +14,7 @@ CONF_DURESS_PIN = "duress"
 CONF_MASTER_PIN = "master"
 
 DEFAULT_MAX_USER_PINS = 4
+MAX_PIN_LENGTH = 4
 
 RESERVED_PIN_LABELS = (CONF_DURESS_PIN, CONF_MASTER_PIN)
 
@@ -174,6 +175,14 @@ class System:
 
     async def set_pin(self, label: str, pin: str) -> None:
         """Set a PIN."""
+        if len(pin) != MAX_PIN_LENGTH:
+            raise PinError("PINs must be {0} digits long".format(MAX_PIN_LENGTH))
+
+        try:
+            int(pin)
+        except ValueError:
+            raise PinError("PINs can only contain numbers")
+
         # Because SimpliSafe's API works by sending the entire payload of PINs, we
         # can't reasonably check a local cache for up-to-date PIN data; so, we fetch the
         # latest each time.


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes bugs with two edge cases when setting PINs:

* PINs that are anything other than 4 characters long
* PINs that are anything other than numeric

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests is written for the new functionality.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
