### PR TITLE
Add "camera" as a valid sensor type

### DIFF
--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -22,6 +22,7 @@ class SensorTypes(Enum):
     smoke = 8
     leak = 9
     temperature = 10
+    camera = 12
     siren = 13
     unknown = 99
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds cameras as a valid sensor type. Note that it does not actually do anything _with_ cameras, camera streams, etc. – it just allows camera "types" to be recognized.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
