### PR TITLE
Fixes multiple lines of code with an added ".items()"

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,3 +8,4 @@
 
 - Scott Newman (https://github.com/greencoder)
 - William Scanlon (https://github.com/w1ll1am23)
+- Kendell Richards (https://github.com/KTibow)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             # Return the number of seconds an activated alarm will sound for:
             system.alarm_duration
             # >>> 240
@@ -310,7 +310,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             for serial, sensor_attrs in system.sensors.items():
                 # Return the sensor's name:
                 sensor.name
@@ -358,7 +358,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             for serial, sensor_attrs in system.sensors.items():
                 # Return the sensor's data as a currently non-understood integer:
                 sensor.data
@@ -386,7 +386,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             for sensor in system.sensors:
                 # Return whether the sensor is offline:
                 sensor.offline
@@ -421,7 +421,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             # Get all PINs (retrieving fresh or from the cache):
             await system.get_pins(cached=False)
             # >>> {"master": "1234", "duress": "9876"}
@@ -471,7 +471,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system_id, system in systems:
+        for system_id, system in systems.items():
             # Return the current access token:
             system.api._access_token
             # >>> 7s9yasdh9aeu21211add
@@ -520,7 +520,7 @@ async def main() -> None:
         )
 
         systems = await simplisafe.get_systems()
-        for system in systems:
+        for system in systems.items():
             # Assuming the access token was automatically refreshed:
             primary_system.api.refresh_token_dirty
             # >>> True


### PR DESCRIPTION
This pull request fixes multiple errors in the documentation.
Basically, I changed all `for system_id, system in systems:` into `for system_id, system in systems.items():` because Python doesn't like the first one.

Fixes https://github.com/bachya/simplisafe-python/issues/41

Because it's a documentation error, there were no tests written for it anyway, so I figured that it'd be the best to leave things how they were.
