### PR TITLE
Switch to f-strings (and remove support for Python 3.5.3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,8 @@ hard work!
 
 `simplisafe-python` is currently supported on:
 
-* Python 3.5
 * Python 3.6
 * Python 3.7
-
-However, running the test suite currently requires Python 3.6 or higher; tests
-run on Python 3.5 will fail.
 
 # Standard vs. Interactive SimpliSafe™ Plans
 

--- a/setup.py
+++ b/setup.py
@@ -14,19 +14,19 @@ from shutil import rmtree
 from setuptools import find_packages, setup, Command  # type: ignore
 
 # Package meta-data.
-NAME = 'simplisafe-python'
-ALIAS = 'simplipy'
-DESCRIPTION = 'A Python3, async interface to the SimpliSafe API'
-URL = 'https://github.com/bachya/simplisafe-python'
-EMAIL = 'bachya1208@gmail.com'
-AUTHOR = 'Aaron Bach'
-REQUIRES_PYTHON = '>=3.5.3'
+NAME = "simplisafe-python"
+ALIAS = "simplipy"
+DESCRIPTION = "A Python3, async interface to the SimpliSafe API"
+URL = "https://github.com/bachya/simplisafe-python"
+EMAIL = "bachya1208@gmail.com"
+AUTHOR = "Aaron Bach"
+REQUIRES_PYTHON = ">=3.6"
 VERSION = None
 
 # What packages are required for this module to be executed?
 REQUIRED = [  # type: ignore
-    'aiohttp',
-    'async-timeout',
+    "aiohttp",
+    "async-timeout",
 ]
 
 # The rest you shouldn't have to touch too much :)
@@ -39,28 +39,28 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 
 # Import the README and use it as the long-description.
 # Note: this will only work if 'README.md' is present in your MANIFEST.in file!
-with io.open(os.path.join(HERE, 'README.md'), encoding='utf-8') as f:
-    LONG_DESC = '\n' + f.read()
+with io.open(os.path.join(HERE, "README.md"), encoding="utf-8") as f:
+    LONG_DESC = "\n" + f.read()
 
 # Load the package's __version__.py module as a dictionary.
 ABOUT = {}  # type: ignore
 if not VERSION:
-    with open(os.path.join(HERE, ALIAS, '__version__.py')) as f:
+    with open(os.path.join(HERE, ALIAS, "__version__.py")) as f:
         exec(f.read(), ABOUT)  # pylint: disable=exec-used
 else:
-    ABOUT['__version__'] = VERSION
+    ABOUT["__version__"] = VERSION
 
 
 class UploadCommand(Command):
     """Support setup.py upload."""
 
-    description = 'Build and publish the package.'
+    description = "Build and publish the package."
     user_options = []  # type: ignore
 
     @staticmethod
     def status(string):
         """Prints things in bold."""
-        print('\033[1m{0}\033[0m'.format(string))
+        print(f"\033[1m{string}\033[0m")
 
     def initialize_options(self):
         """Add options for initialization."""
@@ -73,21 +73,20 @@ class UploadCommand(Command):
     def run(self):
         """Run."""
         try:
-            self.status('Removing previous builds…')
-            rmtree(os.path.join(HERE, 'dist'))
+            self.status("Removing previous builds…")
+            rmtree(os.path.join(HERE, "dist"))
         except OSError:
             pass
 
-        self.status('Building Source and Wheel (universal) distribution…')
-        os.system('{0} setup.py sdist bdist_wheel --universal'.format(
-            sys.executable))
+        self.status("Building Source and Wheel (universal) distribution…")
+        os.system(f"{sys.executable} setup.py sdist bdist_wheel --universal")
 
-        self.status('Uploading the package to PyPi via Twine…')
-        os.system('twine upload dist/*')
+        self.status("Uploading the package to PyPi via Twine…")
+        os.system("twine upload dist/*")
 
-        self.status('Pushing git tags…')
-        os.system('git tag v{0}'.format(ABOUT['__version__']))
-        os.system('git push --tags')
+        self.status("Pushing git tags…")
+        os.system(f'git tag v{ABOUT["version"]}')
+        os.system("git push --tags")
 
         sys.exit()
 
@@ -95,38 +94,34 @@ class UploadCommand(Command):
 # Where the magic happens:
 setup(
     name=NAME,
-    version=ABOUT['__version__'],
+    version=ABOUT["__version__"],
     description=DESCRIPTION,
     long_description=LONG_DESC,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     author=AUTHOR,
     # author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=('tests',)),
+    packages=find_packages(exclude=("tests",)),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
-
     # entry_points={
     #     'console_scripts': ['mycli=mymodule:cli'],
     # },
     install_requires=REQUIRED,
     include_package_data=True,
-    license='MIT',
+    license="MIT",
     classifiers=[
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
-        'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy'
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
     ],
     # $ setup.py publish support.
-    cmdclass={
-        'upload': UploadCommand,
-    },
+    cmdclass={"upload": UploadCommand},
 )

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -20,7 +20,7 @@ DEFAULT_AUTH_USERNAME = "{0}.2074.0.0.com.simplisafe.mobile"
 SYSTEM_MAP = {2: SystemV2, 3: SystemV3}
 
 URL_HOSTNAME = "api.simplisafe.com"
-URL_BASE = "https://{0}/v1".format(URL_HOSTNAME)
+URL_BASE = f"https://{URL_HOSTNAME}/v1"
 
 ApiType = TypeVar("ApiType", bound="API")
 
@@ -131,9 +131,7 @@ class API:
     async def get_subscription_data(self) -> dict:
         """Get the latest location-level data."""
         subscription_resp = await self.request(
-            "get",
-            "users/{0}/subscriptions".format(self.user_id),
-            params={"activeOnly": "true"},
+            "get", f"users/{self.user_id}/subscriptions", params={"activeOnly": "true"}
         )
 
         _LOGGER.debug("Subscription response: %s", subscription_resp)
@@ -149,7 +147,7 @@ class API:
         params: dict = None,
         data: dict = None,
         json: dict = None,
-        **kwargs
+        **kwargs,
     ) -> dict:
         """Make a request."""
         if (
@@ -160,12 +158,12 @@ class API:
             self._actively_refreshing = True
             await self._refresh_access_token(self._refresh_token)
 
-        url = "{0}/{1}".format(URL_BASE, endpoint)
+        url = f"{URL_BASE}/{endpoint}"
 
         if not headers:
             headers = {}
         if not kwargs.get("auth") and self._access_token:
-            headers["Authorization"] = "Bearer {0}".format(self._access_token)
+            headers["Authorization"] = f"Bearer {self._access_token}"
         headers.update({"Host": URL_HOSTNAME, "User-Agent": DEFAULT_USER_AGENT})
 
         try:
@@ -176,7 +174,7 @@ class API:
                 params=params,
                 data=data,
                 json=json,
-                **kwargs
+                **kwargs,
             ) as resp:
                 resp.raise_for_status()
                 return await resp.json(content_type=None)
@@ -195,7 +193,7 @@ class API:
                         params=params,
                         data=data,
                         json=json,
-                        **kwargs
+                        **kwargs,
                     )
                 raise InvalidCredentialsError
             if "403" in str(err):
@@ -204,6 +202,4 @@ class API:
                     return {}
                 raise InvalidCredentialsError
 
-            raise RequestError(
-                "Error requesting data from {0}: {1}".format(endpoint, err)
-            )
+            raise RequestError(f"Error requesting data from {endpoint}: {err}")

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -90,9 +90,7 @@ class SensorV2(Sensor):
         if self.type == SensorTypes.entry:
             return self.sensor_data.get("entryStatus", "closed") == "open"
 
-        raise SimplipyError(
-            "Cannot determine triggered state for sensor: {0}".format(self.name)
-        )
+        raise SimplipyError(f"Cannot determine triggered state for sensor: {self.name}")
 
 
 class SensorV3(Sensor):

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -128,7 +128,5 @@ def unavailable_feature_json():
     return {
         "errorType": "NoRemoteManagement",
         "code": 403,
-        "message": "Subscription {0} does not support remote management".format(
-            TEST_SUBSCRIPTION_ID
-        ),
+        "message": f"Subscription {TEST_SUBSCRIPTION_ID} does not support remote management",
     }

--- a/tests/fixtures/v2.py
+++ b/tests/fixtures/v2.py
@@ -33,13 +33,13 @@ def v2_server(
     )
     server.add(
         "api.simplisafe.com",
-        "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+        f"/v1/users/{TEST_USER_ID}/subscriptions",
         "get",
         aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
     )
     server.add(
         "api.simplisafe.com",
-        "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+        f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
         "get",
         aresponses.Response(text=json.dumps(v2_settings_json), status=200),
     )

--- a/tests/fixtures/v3.py
+++ b/tests/fixtures/v3.py
@@ -38,19 +38,19 @@ def v3_server(
     )
     server.add(
         "api.simplisafe.com",
-        "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+        f"/v1/users/{TEST_USER_ID}/subscriptions",
         "get",
         aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
     )
     server.add(
         "api.simplisafe.com",
-        "/v1/ss3/subscriptions/{0}/sensors".format(TEST_SUBSCRIPTION_ID),
+        f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
         "get",
         aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
     )
     server.add(
         "api.simplisafe.com",
-        "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+        f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
         "get",
         aresponses.Response(text=json.dumps(v3_settings_json), status=200),
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,13 +47,13 @@ async def test_401_refresh_token_failure(
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
             aresponses.Response(text="", status=401),
         )
@@ -88,7 +88,7 @@ async def test_401_refresh_token_success(
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text="", status=401),
         )
@@ -106,13 +106,13 @@ async def test_401_refresh_token_success(
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
             aresponses.Response(text=json.dumps(v2_settings_json), status=200),
         )
@@ -261,19 +261,19 @@ async def test_unavailable_feature_v2(
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
             aresponses.Response(text=json.dumps(unavailable_feature_json), status=403),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/state".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/state",
             "post",
             aresponses.Response(text=json.dumps(unavailable_feature_json), status=403),
         )
@@ -322,25 +322,25 @@ async def test_unavailable_feature_v3(
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/sensors".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
             "get",
             aresponses.Response(text=json.dumps(unavailable_feature_json), status=403),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/state/{1}".format(TEST_SUBSCRIPTION_ID, "away"),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/state/away",
             "post",
             aresponses.Response(text=json.dumps(unavailable_feature_json), status=403),
         )

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -33,7 +33,7 @@ async def test_get_events(events_json, event_loop, v2_server):
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/events".format(TEST_SYSTEM_ID),
+            f"/v1/subscriptions/{TEST_SYSTEM_ID}/events",
             "get",
             aresponses.Response(text=json.dumps(events_json), status=200),
         )
@@ -54,7 +54,7 @@ async def test_get_last_event(event_loop, v3_server, latest_event_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/events".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/events",
             "get",
             aresponses.Response(text=json.dumps(latest_event_json), status=200),
         )
@@ -74,7 +74,7 @@ async def test_get_pins_v2(event_loop, v2_pins_json, v2_server):
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/pins",
             "get",
             aresponses.Response(text=json.dumps(v2_pins_json), status=200),
         )
@@ -98,7 +98,7 @@ async def test_get_pins_v3(event_loop, v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -144,13 +144,13 @@ async def test_get_systems_v2(
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
             aresponses.Response(text=json.dumps(v2_settings_json), status=200),
         )
@@ -208,19 +208,19 @@ async def test_get_systems_v3(
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/sensors".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
             "get",
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -257,7 +257,7 @@ async def test_remove_nonexistent_pin_v3(event_loop, v3_server, v3_settings_json
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -280,19 +280,19 @@ async def test_remove_pin_v3(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "post",
             aresponses.Response(
                 text=json.dumps(v3_settings_deleted_pin_json), status=200
@@ -300,7 +300,7 @@ async def test_remove_pin_v3(
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(
                 text=json.dumps(v3_settings_deleted_pin_json), status=200
@@ -326,7 +326,7 @@ async def test_remove_reserved_pin_v3(event_loop, v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -347,13 +347,13 @@ async def test_set_duplicate_pin(event_loop, v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "post",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -378,7 +378,7 @@ async def test_set_max_user_pins(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(
                 text=json.dumps(v3_settings_full_pins_json), status=200
@@ -386,7 +386,7 @@ async def test_set_max_user_pins(
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "post",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -452,25 +452,25 @@ async def test_set_pin_v2(event_loop, v2_new_pins_json, v2_pins_json, v2_server)
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/pins",
             "get",
             aresponses.Response(text=json.dumps(v2_pins_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/pins",
             "get",
             aresponses.Response(text=json.dumps(v2_pins_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/pins",
             "post",
             aresponses.Response(text=None, status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/pins",
             "get",
             aresponses.Response(text=json.dumps(v2_new_pins_json), status=200),
         )
@@ -496,25 +496,25 @@ async def test_set_pin_v3(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "post",
             aresponses.Response(text=json.dumps(v3_settings_new_pin_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_new_pin_json), status=200),
         )
@@ -575,25 +575,25 @@ async def test_set_states_v2(
         # routes:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/state".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/state",
             "post",
             aresponses.Response(text=json.dumps(v2_state_away_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/state".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/state",
             "post",
             aresponses.Response(text=json.dumps(v2_state_home_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/state".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/state",
             "post",
             aresponses.Response(text=json.dumps(v2_state_off_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/state".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/state",
             "post",
             aresponses.Response(text=json.dumps(v2_state_off_json), status=200),
         )
@@ -627,25 +627,25 @@ async def test_set_states_v3(
         # routes:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/state/{1}".format(TEST_SUBSCRIPTION_ID, "away"),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/state/away",
             "post",
             aresponses.Response(text=json.dumps(v3_state_away_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/state/{1}".format(TEST_SUBSCRIPTION_ID, "home"),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/state/home",
             "post",
             aresponses.Response(text=json.dumps(v3_state_home_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/state/{1}".format(TEST_SUBSCRIPTION_ID, "off"),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/state/off",
             "post",
             aresponses.Response(text=json.dumps(v3_state_off_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/state/{1}".format(TEST_SUBSCRIPTION_ID, "off"),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/state/off",
             "post",
             aresponses.Response(text=json.dumps(v3_state_off_json), status=200),
         )
@@ -696,13 +696,13 @@ async def test_update_system_data_v2(
     async with v2_server:
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v2_subscriptions_json), status=200),
         )
         v2_server.add(
             "api.simplisafe.com",
-            "/v1/subscriptions/{0}/settings".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
             aresponses.Response(text=json.dumps(v2_settings_json), status=200),
         )
@@ -728,19 +728,19 @@ async def test_update_system_data_v3(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/sensors".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
             "get",
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -771,19 +771,19 @@ async def test_update_error_v3(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/users/{0}/subscriptions".format(TEST_USER_ID),
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/sensors".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
             "get",
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            "/v1/ss3/subscriptions/{0}/settings/pins".format(TEST_SUBSCRIPTION_ID),
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=500),
         )


### PR DESCRIPTION
**Describe what the PR does:**

This PR drops runtime support for Python 3.5.3 and makes the minimum runtime version 3.6. One of a few benefits to follow: we now get to use f-strings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
