### PR TITLE
Add Python 3.6-style variable type annotations

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,6 +2,8 @@
 exclude_lines =
     # Don't complain if tests don't hit defensive assertion code:
     raise NotImplementedError
+    # Don't include lines that are specifically in place for type-checking:
+    TYPE_CHECKING
 
 [run]
 source = simplipy

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -32,10 +32,10 @@ class Sensor:
 
     def __init__(self, sensor_data: dict) -> None:
         """Initialize."""
-        self.sensor_data = sensor_data
+        self.sensor_data: dict = sensor_data
 
         try:
-            self._type = SensorTypes(sensor_data["type"])
+            self._type: SensorTypes = SensorTypes(sensor_data["type"])
         except ValueError:
             _LOGGER.error("Unknown sensor type: %s", self.sensor_data["type"])
             self._type = SensorTypes.unknown


### PR DESCRIPTION
**Describe what the PR does:**

Now that we can ensure a minimum of Python 3.6, we can use Python 3.6-style type annotations for variables.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
