### PR TITLE
Exclude scripts from published package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     # author_email=EMAIL,
     python_requires=REQUIRES_PYTHON,
     url=URL,
-    packages=find_packages(exclude=("tests",)),
+    packages=find_packages(exclude=("tests", "script")),
     # If your package is a single module, use this instead of 'packages':
     # py_modules=['mypackage'],
     # entry_points={


### PR DESCRIPTION
**Describe what the PR does:**
Recently a `script` folder was added. Because of the way `setup.py` is set up, this was included in the published package, capturing the `script` namespace in Python when installed.

It broke running `hassfest` inside the Home Assistant repo.

