### PR TITLE
Split common functionality into an Entity class

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ async def main() -> None:
 
                 # Return the sensor's type:
                 sensor.type
-                # >>> simplipy.sensor.SensorTypes.glass_break
+                # >>> simplipy.EntityTypes.glass_break
 
                 # Return whether the sensor is in an error state:
                 sensor.error

--- a/simplipy/__init__.py
+++ b/simplipy/__init__.py
@@ -1,2 +1,3 @@
 """Define module-level imports."""
 from .api import API  # noqa
+from .entity import EntityTypes

--- a/simplipy/__init__.py
+++ b/simplipy/__init__.py
@@ -1,3 +1,2 @@
 """Define module-level imports."""
 from .api import API  # noqa
-from .entity import EntityTypes

--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -1,0 +1,53 @@
+"""Define a base SimpliSafe entity."""
+from enum import Enum
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class EntityTypes(Enum):
+    """Define entity types based on internal SimpliSafe ID number."""
+
+    remote = 0
+    keypad = 1
+    keychain = 2
+    panic_button = 3
+    motion = 4
+    entry = 5
+    glass_break = 6
+    carbon_monoxide = 7
+    smoke = 8
+    leak = 9
+    temperature = 10
+    camera = 12
+    siren = 13
+    unknown = 99
+
+
+class Entity:
+    """Define a base SimpliSafe entity."""
+
+    def __init__(self, entity_data: dict) -> None:
+        """Initialize."""
+        self.entity_data: dict = entity_data
+
+        try:
+            self._type: EntityTypes = EntityTypes(entity_data["type"])
+        except ValueError:
+            _LOGGER.error("Unknown entity type: %s", self.entity_data["type"])
+            self._type = EntityTypes.unknown
+
+    @property
+    def name(self) -> str:
+        """Return the entity name."""
+        return self.entity_data["name"]
+
+    @property
+    def serial(self) -> str:
+        """Return the entity number."""
+        return self.entity_data["serial"]
+
+    @property
+    def type(self) -> EntityTypes:
+        """Return the entity type."""
+        return self._type

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -1,146 +1,98 @@
 """Define a SimpliSafe sensor."""
 import logging
-from enum import Enum
 from typing import Optional
 
+from .entity import Entity, EntityTypes
 from .errors import SimplipyError
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class SensorTypes(Enum):
-    """Define sensor types."""
-
-    remote = 0
-    keypad = 1
-    keychain = 2
-    panic_button = 3
-    motion = 4
-    entry = 5
-    glass_break = 6
-    carbon_monoxide = 7
-    smoke = 8
-    leak = 9
-    temperature = 10
-    camera = 12
-    siren = 13
-    unknown = 99
-
-
-class Sensor:
-    """Define a base SimpliSafe sensor."""
-
-    def __init__(self, sensor_data: dict) -> None:
-        """Initialize."""
-        self.sensor_data: dict = sensor_data
-
-        try:
-            self._type: SensorTypes = SensorTypes(sensor_data["type"])
-        except ValueError:
-            _LOGGER.error("Unknown sensor type: %s", self.sensor_data["type"])
-            self._type = SensorTypes.unknown
-
-    @property
-    def name(self) -> str:
-        """Return the sensor name."""
-        return self.sensor_data["name"]
-
-    @property
-    def serial(self) -> str:
-        """Return the serial number."""
-        return self.sensor_data["serial"]
-
-    @property
-    def type(self) -> SensorTypes:
-        """Return the sensor type."""
-        return self._type
-
-
-class SensorV2(Sensor):
+class SensorV2(Entity):
     """Define a V2 (old) sensor."""
 
     @property
     def data(self) -> int:
         """Return the sensor's current data."""
-        return self.sensor_data["sensorData"]
+        return self.entity_data["sensorData"]
 
     @property
     def error(self) -> bool:
         """Return the sensor's error status."""
-        return self.sensor_data["error"]
+        return self.entity_data["error"]
 
     @property
     def low_battery(self) -> bool:
         """Return whether the sensor's battery is low."""
-        return self.sensor_data.get("battery", "ok") != "ok"
+        return self.entity_data.get("battery", "ok") != "ok"
 
     @property
     def settings(self) -> bool:
         """Return the sensor's settings."""
-        return self.sensor_data["setting"]
+        return self.entity_data["setting"]
 
     @property
     def trigger_instantly(self) -> bool:
         """Return whether the sensor will trigger instantly."""
-        return self.sensor_data["instant"]
+        return self.entity_data["instant"]
 
     @property
     def triggered(self) -> bool:
         """Return the current sensor state."""
-        if self.type == SensorTypes.entry:
-            return self.sensor_data.get("entryStatus", "closed") == "open"
+        if self.type == EntityTypes.entry:
+            return self.entity_data.get("entryStatus", "closed") == "open"
 
         raise SimplipyError(f"Cannot determine triggered state for sensor: {self.name}")
 
 
-class SensorV3(Sensor):
+class SensorV3(Entity):
     """Define a V3 (new) sensor."""
 
     @property
     def error(self) -> bool:
         """Return the sensor's error status."""
-        return self.sensor_data["status"].get("malfunction", False)
+        return self.entity_data["status"].get("malfunction", False)
 
     @property
     def low_battery(self) -> bool:
         """Return whether the sensor's battery is low."""
-        return self.sensor_data["flags"]["lowBattery"]
+        return self.entity_data["flags"]["lowBattery"]
 
     @property
     def offline(self) -> bool:
         """Return whether the sensor is offline."""
-        return self.sensor_data["flags"]["offline"]
+        return self.entity_data["flags"]["offline"]
 
     @property
     def settings(self) -> dict:
         """Return the sensor's settings."""
-        return self.sensor_data["setting"]
+        return self.entity_data["setting"]
 
     @property
     def trigger_instantly(self) -> bool:
         """Return whether the sensor will trigger instantly."""
-        return self.sensor_data["setting"]["instantTrigger"]
+        return self.entity_data["setting"]["instantTrigger"]
 
     @property
     def triggered(self) -> bool:
         """Return the sensor's status info."""
         if self.type in (
-            SensorTypes.motion,
-            SensorTypes.entry,
-            SensorTypes.glass_break,
-            SensorTypes.carbon_monoxide,
-            SensorTypes.smoke,
-            SensorTypes.leak,
-            SensorTypes.temperature,
+            EntityTypes.motion,
+            EntityTypes.entry,
+            EntityTypes.glass_break,
+            EntityTypes.carbon_monoxide,
+            EntityTypes.smoke,
+            EntityTypes.leak,
+            EntityTypes.temperature,
         ):
-            return self.sensor_data["status"].get("triggered", False)
+            return self.entity_data["status"].get("triggered", False)
 
         return False
 
     @property
     def temperature(self) -> Optional[int]:
         """Return the sensor's status info."""
-        if self.type != SensorTypes.temperature:
+        if self.type != EntityTypes.temperature:
             raise AttributeError("Non-temperature sensor cannot have a temperature")
 
-        return self.sensor_data["status"]["temperature"]
+        return self.entity_data["status"]["temperature"]

--- a/simplipy/system.py
+++ b/simplipy/system.py
@@ -2,10 +2,10 @@
 import asyncio
 import logging
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Set
+from typing import TYPE_CHECKING, Any, Coroutine, Dict, List, Set, Union
 
 from .errors import InvalidCredentialsError, PinError, SimplipyError
-from .sensor import Sensor, SensorV2, SensorV3
+from .sensor import SensorV2, SensorV3
 from .util.string import convert_to_underscore
 
 if TYPE_CHECKING:
@@ -44,7 +44,7 @@ class System:
         """Initialize."""
         self._location_info: dict = location_info
         self.api: "API" = api
-        self.sensors: Dict[str, Sensor] = {}
+        self.sensors: Dict[str, Union[SensorV2, SensorV3]] = {}
 
         self._state: SystemStates = self._coerce_state_from_string(
             location_info["system"]["alarmState"]
@@ -311,7 +311,7 @@ class SystemV2(System):
 
             if sensor_data["serial"] in self.sensors:
                 sensor = self.sensors[sensor_data["serial"]]
-                sensor.sensor_data = sensor_data
+                sensor.entity_data = sensor_data
             else:
                 self.sensors[sensor_data["serial"]] = SensorV2(sensor_data)
 
@@ -481,7 +481,7 @@ class SystemV3(System):
         for sensor_data in sensor_resp["sensors"]:
             if sensor_data["serial"] in self.sensors:
                 sensor = self.sensors[sensor_data["serial"]]
-                sensor.sensor_data = sensor_data
+                sensor.entity_data = sensor_data
             else:
                 self.sensors[sensor_data["serial"]] = SensorV3(sensor_data)
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -5,8 +5,8 @@ import aiohttp
 import pytest
 
 from simplipy import API
+from simplipy.entity import EntityTypes
 from simplipy.errors import SimplipyError
-from simplipy.sensor import SensorTypes
 
 from .const import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 from .fixtures import *
@@ -26,7 +26,7 @@ async def test_properties_base(event_loop, v2_server):
             sensor = system.sensors["195"]
             assert sensor.name == "Garage Keypad"
             assert sensor.serial == "195"
-            assert sensor.type == SensorTypes.keypad
+            assert sensor.type == EntityTypes.keypad
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR splits out common sensor functionality into an `Entity` class. With support for locks on the horizon (https://github.com/bachya/simplisafe-python/issues/47), I want to start to demarcate between `Sensor` and `Lock` objects (even though they have a common ancestor).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
