### PR TITLE
Re-work how sensors are instantiated

### DIFF
--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -27,15 +27,10 @@ class EntityTypes(Enum):
 class Entity:
     """Define a base SimpliSafe entity."""
 
-    def __init__(self, entity_data: dict) -> None:
+    def __init__(self, entity_type: EntityTypes, entity_data: dict) -> None:
         """Initialize."""
+        self._type = entity_type
         self.entity_data: dict = entity_data
-
-        try:
-            self._type: EntityTypes = EntityTypes(entity_data["type"])
-        except ValueError:
-            _LOGGER.error("Unknown entity type: %s", self.entity_data["type"])
-            self._type = EntityTypes.unknown
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
**Describe what the PR does:**

This PR reworks how sensors are instantiated by putting more of the onus on the `System` object. This new architecture lays additional groundwork for eventually being able to support other types of SimpliSafe entities, like locks.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
