### PR TITLE
Create concept of a V3 entity

### DIFF
--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -46,3 +46,27 @@ class Entity:
     def type(self) -> EntityTypes:
         """Return the entity type."""
         return self._type
+
+
+class EntityV3(Entity):
+    """Define a base SimpliSafe V3 entity."""
+
+    @property
+    def error(self) -> bool:
+        """Return the entity's error status."""
+        return self.entity_data["status"].get("malfunction", False)
+
+    @property
+    def low_battery(self) -> bool:
+        """Return whether the entity's battery is low."""
+        return self.entity_data["flags"]["lowBattery"]
+
+    @property
+    def offline(self) -> bool:
+        """Return whether the entity is offline."""
+        return self.entity_data["flags"]["offline"]
+
+    @property
+    def settings(self) -> dict:
+        """Return the entity's settings."""
+        return self.entity_data["setting"]

--- a/simplipy/sensor.py
+++ b/simplipy/sensor.py
@@ -2,7 +2,7 @@
 import logging
 from typing import Optional
 
-from .entity import Entity, EntityTypes
+from .entity import Entity, EntityTypes, EntityV3
 from .errors import SimplipyError
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
@@ -45,28 +45,8 @@ class SensorV2(Entity):
         raise SimplipyError(f"Cannot determine triggered state for sensor: {self.name}")
 
 
-class SensorV3(Entity):
+class SensorV3(EntityV3):
     """Define a V3 (new) sensor."""
-
-    @property
-    def error(self) -> bool:
-        """Return the sensor's error status."""
-        return self.entity_data["status"].get("malfunction", False)
-
-    @property
-    def low_battery(self) -> bool:
-        """Return whether the sensor's battery is low."""
-        return self.entity_data["flags"]["lowBattery"]
-
-    @property
-    def offline(self) -> bool:
-        """Return whether the sensor is offline."""
-        return self.entity_data["flags"]["offline"]
-
-    @property
-    def settings(self) -> dict:
-        """Return the sensor's settings."""
-        return self.entity_data["setting"]
 
     @property
     def trigger_instantly(self) -> bool:


### PR DESCRIPTION
**Describe what the PR does:**

This PR introduces a subclass of `Entity` called `EntityV3` – this provides common methods and attributes to all V3 entities, including sensors and (soon) locks.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
