### PR TITLE
Make InvalidCredentialsError instances more verbose

### DIFF
--- a/example_locks.py
+++ b/example_locks.py
@@ -41,8 +41,6 @@ async def main() -> None:
                         await asyncio.sleep(3)
                         _LOGGER.info("Locking...")
                         await lock.lock()
-        except InvalidCredentialsError:
-            _LOGGER.error("Invalid credentials")
         except SimplipyError as err:
             _LOGGER.error(err)
 

--- a/example_sensors_properties.py
+++ b/example_sensors_properties.py
@@ -42,8 +42,6 @@ async def main() -> None:
                         sensor.type,
                         sensor.triggered,
                     )
-        except InvalidCredentialsError:
-            _LOGGER.error("Invalid credentials")
         except SimplipyError as err:
             _LOGGER.error(err)
 

--- a/example_setting_state.py
+++ b/example_setting_state.py
@@ -27,8 +27,6 @@ async def main() -> None:
                 await system.set_home()
                 await asyncio.sleep(3)
                 await system.set_off()
-        except InvalidCredentialsError:
-            _LOGGER.error("Invalid credentials")
         except SimplipyError as err:
             _LOGGER.error(err)
 


### PR DESCRIPTION
**Describe what the PR does:**

In several places, I throw an `InvalidCredentialsError` without a message; this can lead to confusing log outputs. This PR makes those instances a little clearer.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
