### PR TITLE
Add experimental support for SimpliSafe websocket

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ and more.
    system
    sensor
    lock
+   websocket
    advanced
    api
 

--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -1,7 +1,7 @@
 Locks
 =====
 
-``Lock`` objects correspond to SimpliSafe locks (only available for V3 systems) and
+``Lock`` objects correspond to SimpliSafe™ locks (only available for V3 systems) and
 allows users to retrieve information on them and alter their state by
 locking/unlocking them.
 

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -75,9 +75,3 @@ connection is established:
 
     simplisafe.websocket.async_on_disconnect(async_event_handler)
     simplisafe.websocket.on_disconnect(sync_event_handler)
-
-Full Example
-------------
-
-A full example can be found within the `GitHub repo <https://github.com/bachya/simplisafe-python/blob/dev/tests/test_websocket.py>`_
-at ``scripts/test_websocket.py``.

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -75,3 +75,31 @@ connection is established:
 
     simplisafe.websocket.async_on_disconnect(async_event_handler)
     simplisafe.websocket.on_disconnect(sync_event_handler)
+
+The data returned in the ``data`` argument has the same schema as data returned from
+``system.get_events()``. For example, when the system is armed in home mode, users may
+expect a ``data`` argument with this value:
+
+.. code:: json
+
+    {
+      "eventId": 1231231231,
+      "eventTimestamp": 1231231231,
+      "eventCid": 1231,
+      "zoneCid": "3",
+      "sensorType": 0,
+      "sensorSerial": "",
+      "account": "xxxxxxxx",
+      "userId": 123123,
+      "sid": 123123,
+      "info": "System Armed (Home) by Remote Management",
+      "pinName": "",
+      "sensorName": "",
+      "messageSubject": "SimpliSafe System Armed (home mode)",
+      "messageBody": "System Armed (home mode)",
+      "eventType": "activity",
+      "timezone": 2,
+      "locationOffset": -420,
+      "videoStartedBy": "",
+      "video": {}
+    }

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -1,0 +1,83 @@
+Websocket
+=========
+
+**NOTE:** this feature is ``experimental`` and should be used with caution.
+
+``simplipy`` provides a websocket that allows for near-real-time detection of certain
+events from a user's SimpliSafe™ system. This websocket can be accessed via the
+``websocket`` property of the ``API`` object:
+
+.. code:: python
+
+    simplisafe = await API.login_via_credentials(
+        "<EMAIL>", "<PASSWORD>", websession
+    )
+
+    simplisafe.websocket
+    # >>> <simplipy.websocket.Websocket object>
+
+Responding to Events
+--------------------
+
+Users are currently able to subscribe to the following events:
+
+* ``connect``: occurs when the websocket connection is established
+* ``disconnect``: occurs when the websocket connection is terminated
+* ``event``: occurs when any data is transmitted from the SimpliSafe™ cloud
+
+Users respond to events by defining handlers (synchronous functions *or* coroutines) and
+using the appropriate registration method.
+
+``connect``
+***********
+
+For example, to register two handlers that should be executed when the websocket
+connection is established:
+
+.. code:: python
+
+    def sync_connect_handler():
+        print("Connected to the websocket")
+
+    async def async_connect_handler():
+        print("I also connected to the websocket")
+
+    # Use the correct registration method: sync for sync, async
+    # for async. Also note that each registration method can be
+    # used for multiple handlers!
+    simplisafe.websocket.async_on_connect(async_connect_handler)
+    simplisafe.websocket.on_connect(sync_connect_handler)
+
+``disconnect``
+**************
+
+.. code:: python
+
+    def sync_disconnect_handler():
+        print("Disconnected from the websocket")
+
+    async def async_disconnect_handler():
+        print("I also disconnected from the websocket")
+
+    simplisafe.websocket.async_on_disconnect(async_disconnect_handler)
+    simplisafe.websocket.on_disconnect(sync_disconnect_handler)
+
+``event``
+**************
+
+.. code:: python
+
+    def sync_event_handler(data):
+        print(f"I got some data: {data}")
+
+    async def async_event_handler():
+        print(f"I also got some data: {data}")
+
+    simplisafe.websocket.async_on_disconnect(async_event_handler)
+    simplisafe.websocket.on_disconnect(sync_event_handler)
+
+Full Example
+------------
+
+A full example can be found within the `GitHub repo <https://github.com/bachya/simplisafe-python/blob/dev/tests/test_websocket.py>`_
+at ``scripts/test_websocket.py``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,11 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6"
 aiohttp = "^3.6.2"
+python = "^3.6.1"
+python-engineio = ">= 3.9.3"
+python-socketio = ">=4.3.1"
+websockets = "^8.1"
 
 [tool.poetry.dev-dependencies]
 Sphinx = "^2.2.1"

--- a/scripts/get_events.py
+++ b/scripts/get_events.py
@@ -9,8 +9,8 @@ from simplipy.errors import SimplipyError
 
 _LOGGER = logging.getLogger()
 
-SIMPLISAFE_EMAIL = "<EMAIL>"
-SIMPLISAFE_PASSWORD = "<PASSWORD>"
+SIMPLISAFE_EMAIL = "bachya1208@gmail.com"
+SIMPLISAFE_PASSWORD = "rkzmPyb*2*o6vT4ENJNCpAq3k"
 
 
 async def main() -> None:

--- a/scripts/test_websocket.py
+++ b/scripts/test_websocket.py
@@ -1,0 +1,61 @@
+"""Run an example script to exercise the websocket."""
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from simplipy import API
+from simplipy.errors import SimplipyError, WebsocketError
+
+_LOGGER = logging.getLogger()
+
+SIMPLISAFE_EMAIL = "<EMAIL>"
+SIMPLISAFE_PASSWORD = "<PASSWORD>"
+
+
+def print_data(data):
+    """Print data as it is received."""
+    _LOGGER.info("Data received: %s", data)
+
+
+def print_goodbye():
+    """Print a simple "goodbye" message."""
+    _LOGGER.info("Client has disconnected from the websocket")
+
+
+def print_hello():
+    """Print a simple "hello" message."""
+    _LOGGER.info("Client has connected to the websocket")
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as websession:
+        logging.basicConfig(level=logging.INFO)
+
+        try:
+            simplisafe = await API.login_via_credentials(
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+            )
+
+            simplisafe.websocket.on_connect(print_hello)
+            simplisafe.websocket.on_disconnect(print_goodbye)
+            simplisafe.websocket.on_event(print_data)
+
+            try:
+                await simplisafe.websocket.async_connect()
+            except WebsocketError as err:
+                _LOGGER.error("There was a websocket error: %s", err)
+                return
+
+            for _ in range(30):
+                _LOGGER.info("Simulating some other task occurring...")
+                await asyncio.sleep(5)
+
+            await simplisafe.websocket.async_disconnect()
+
+        except SimplipyError as err:
+            _LOGGER.error(err)
+
+
+asyncio.get_event_loop().run_until_complete(main())

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -11,6 +11,7 @@ from simplipy.errors import InvalidCredentialsError, RequestError
 from simplipy.system import System
 from simplipy.system.v2 import SystemV2
 from simplipy.system.v3 import SystemV3
+from simplipy.websocket import Websocket
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -19,8 +20,8 @@ DEFAULT_AUTH_USERNAME: str = "{0}.2074.0.0.com.simplisafe.mobile"
 
 SYSTEM_MAP: Dict[int, Type[System]] = {2: SystemV2, 3: SystemV3}
 
-URL_HOSTNAME: str = "api.simplisafe.com"
-URL_BASE: str = f"https://{URL_HOSTNAME}/v1"
+API_URL_HOSTNAME: str = "api.simplisafe.com"
+API_URL_BASE: str = f"https://{API_URL_HOSTNAME}/v1"
 
 ApiType = TypeVar("ApiType", bound="API")
 
@@ -39,6 +40,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.email: Optional[str] = None
         self.refresh_token_dirty: bool = False
         self.user_id: Optional[str] = None
+        self.websocket: Optional[Websocket] = None
 
     @property
     def refresh_token(self) -> str:
@@ -102,6 +104,11 @@ class API:  # pylint: disable=too-many-instance-attributes
         auth_check_resp: dict = await self.request("get", "api/authCheck")
         self.user_id = auth_check_resp["userId"]
 
+        if self.websocket:
+            self.websocket.access_token = self._access_token
+        else:
+            self.websocket = Websocket(self._access_token, self.user_id)
+
     async def get_systems(self) -> Dict[str, System]:
         """Get systems associated to this account."""
         subscription_resp: dict = await self.get_subscription_data()
@@ -162,12 +169,12 @@ class API:  # pylint: disable=too-many-instance-attributes
             headers = {}
         if not kwargs.get("auth") and self._access_token:
             headers["Authorization"] = f"Bearer {self._access_token}"
-        headers.update({"Host": URL_HOSTNAME, "User-Agent": DEFAULT_USER_AGENT})
+        headers.update({"Host": API_URL_HOSTNAME, "User-Agent": DEFAULT_USER_AGENT})
 
         try:
             async with self._websession.request(
                 method,
-                f"{URL_BASE}/{endpoint}",
+                f"{API_URL_BASE}/{endpoint}",
                 headers=headers,
                 params=params,
                 data=data,

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -39,7 +39,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._websession: ClientSession = websession
         self.email: Optional[str] = None
         self.refresh_token_dirty: bool = False
-        self.user_id: Optional[str] = None
+        self.user_id: Optional[int] = None
         self.websocket: Optional[Websocket] = None
 
     @property
@@ -107,7 +107,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         if self.websocket:
             self.websocket.access_token = self._access_token
         else:
-            self.websocket = Websocket(self._access_token, self.user_id)
+            self.websocket = Websocket(self._access_token, self.user_id)  # type: ignore
 
     async def get_systems(self) -> Dict[str, System]:
         """Get systems associated to this account."""

--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -23,3 +23,9 @@ class RequestError(SimplipyError):
     """Define an error related to invalid requests."""
 
     pass
+
+
+class WebsocketError(SimplipyError):
+    """Define an error related to generic websocket errors."""
+
+    pass

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -42,7 +42,7 @@ class Websocket:
         elif self._sync_disconnect_handler:
             self._sync_disconnect_handler()
 
-    async def async_on_connect(self, target: Callable[..., Awaitable]) -> None:
+    def async_on_connect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when connecting."""
         self.on_connect(target)
 
@@ -50,7 +50,7 @@ class Websocket:
         """Define a synchronous method to be called when connecting."""
         self._sio.on("connect", target)
 
-    async def async_on_disconnect(self, target: Callable[..., Awaitable]) -> None:
+    def async_on_disconnect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when disconnecting."""
         self._async_disconnect_handler = target
 
@@ -58,7 +58,7 @@ class Websocket:
         """Define a synchronous method to be called when disconnecting."""
         self._sync_disconnect_handler = target
 
-    async def async_on_event(self, target: Callable[..., Awaitable]) -> None:
+    def async_on_event(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called an event is received."""
         self.on_event(target)
 

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -1,6 +1,5 @@
 """Define a connection to the SimpliSafe websocket."""
-import asyncio
-from typing import Awaitable, Callable, Optional, Union
+from typing import Awaitable, Callable, Optional
 from urllib.parse import urlencode
 
 from socketio import AsyncClient
@@ -16,7 +15,7 @@ class Websocket:
 
     def __init__(self, access_token: str, user_id: int) -> None:
         """Initialize."""
-        self._async_disconnect_handler: Optional[Awaitable] = None
+        self._async_disconnect_handler: Optional[Callable[..., Awaitable]] = None
         self._namespace = f"/v1/user/{user_id}"
         self._sio: AsyncClient = AsyncClient()
         self._sync_disconnect_handler: Optional[Callable] = None
@@ -43,7 +42,7 @@ class Websocket:
         elif self._sync_disconnect_handler:
             self._sync_disconnect_handler()
 
-    async def async_on_connect(self, target: Awaitable) -> None:
+    async def async_on_connect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when connecting."""
         self.on_connect(target)
 
@@ -51,7 +50,7 @@ class Websocket:
         """Define a synchronous method to be called when connecting."""
         self._sio.on("connect", target)
 
-    async def async_on_disconnect(self, target: Awaitable) -> None:
+    async def async_on_disconnect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when disconnecting."""
         self._async_disconnect_handler = target
 
@@ -59,7 +58,7 @@ class Websocket:
         """Define a synchronous method to be called when disconnecting."""
         self._sync_disconnect_handler = target
 
-    async def async_on_event(self, target: Awaitable) -> None:
+    async def async_on_event(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called an event is received."""
         self.on_event(target)
 

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -1,0 +1,68 @@
+"""Define a connection to the SimpliSafe websocket."""
+import asyncio
+from typing import Awaitable, Callable, Optional, Union
+from urllib.parse import urlencode
+
+from socketio import AsyncClient
+from socketio.exceptions import ConnectionError as ConnError, SocketIOError
+
+from simplipy.errors import WebsocketError
+
+API_URL_BASE: str = "wss://api.simplisafe.com/socket.io"
+
+
+class Websocket:
+    """Define to handler."""
+
+    def __init__(self, access_token: str, user_id: int) -> None:
+        """Initialize."""
+        self._async_disconnect_handler: Optional[Awaitable] = None
+        self._namespace = f"/v1/user/{user_id}"
+        self._sio: AsyncClient = AsyncClient()
+        self._sync_disconnect_handler: Optional[Callable] = None
+        self._user_id = user_id
+        self.access_token: str = access_token
+
+    async def async_connect(self) -> None:
+        """Connect to the socket."""
+        params = {"ns": self._namespace, "accessToken": self.access_token}
+        try:
+            await self._sio.connect(
+                f"{API_URL_BASE}?{urlencode(params)}",
+                namespaces=[self._namespace],
+                transports=["websocket"],
+            )
+        except (ConnError, SocketIOError) as err:
+            raise WebsocketError(err) from None
+
+    async def async_disconnect(self) -> None:
+        """Disconnect from the socket."""
+        await self._sio.disconnect()
+        if self._async_disconnect_handler:
+            await self._async_disconnect_handler()
+        elif self._sync_disconnect_handler:
+            self._sync_disconnect_handler()
+
+    async def async_on_connect(self, target: Awaitable) -> None:
+        """Define a coroutine to be called when connecting."""
+        self.on_connect(target)
+
+    def on_connect(self, target: Callable) -> None:
+        """Define a synchronous method to be called when connecting."""
+        self._sio.on("connect", target)
+
+    async def async_on_disconnect(self, target: Awaitable) -> None:
+        """Define a coroutine to be called when disconnecting."""
+        self._async_disconnect_handler = target
+
+    def on_disconnect(self, target: Callable) -> None:
+        """Define a synchronous method to be called when disconnecting."""
+        self._sync_disconnect_handler = target
+
+    async def async_on_event(self, target: Awaitable) -> None:
+        """Define a coroutine to be called an event is received."""
+        self.on_event(target)
+
+    def on_event(self, target: Callable) -> None:
+        """Define a synchronous method to be called when an event is received."""
+        self._sio.on("event", target, namespace=self._namespace)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,185 @@
+"""Define tests for the Websocket API."""
+import aiohttp
+import pytest
+from unittest.mock import patch, MagicMock
+from urllib.parse import urlencode
+
+from socketio.exceptions import SocketIOError
+
+from simplipy import API
+from simplipy.errors import WebsocketError
+
+from .const import TEST_ACCESS_TOKEN, TEST_EMAIL, TEST_PASSWORD, TEST_USER_ID
+from .fixtures import *  # noqa
+from .fixtures.v3 import *  # noqa
+
+
+def async_mock(*args, **kwargs):
+    """Return a mock asynchronous function."""
+    m = MagicMock(*args, **kwargs)
+
+    async def mock_coro(*args, **kwargs):
+        return m(*args, **kwargs)
+
+    mock_coro.mock = m
+    return mock_coro
+
+
+@pytest.mark.asyncio
+async def test_connect_async_success(event_loop, v3_server):
+    """Test triggering an async handler upon connection to the websocket."""
+    async with v3_server:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            api.websocket._sio.eio._trigger_event = async_mock()
+            api.websocket._sio.eio.connect = async_mock()
+
+            on_connect = async_mock()
+            api.websocket.async_on_connect(on_connect)
+
+            connect_params = {
+                "ns": f"/v1/user/{TEST_USER_ID}",
+                "accessToken": TEST_ACCESS_TOKEN,
+            }
+
+            await api.websocket.async_connect()
+            api.websocket._sio.eio.connect.mock.assert_called_once_with(
+                f"wss://api.simplisafe.com/socket.io?{urlencode(connect_params)}",
+                engineio_path="socket.io",
+                headers={},
+                transports=["websocket"],
+            )
+
+            await api.websocket._sio._trigger_event("connect", namespace="/")
+            on_connect.mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_sync_success(event_loop, v3_server):
+    """Test triggering a synchronous handler upon connection to the websocket."""
+    async with v3_server:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            api.websocket._sio.eio._trigger_event = async_mock()
+            api.websocket._sio.eio.connect = async_mock()
+
+            on_connect = MagicMock()
+            api.websocket.on_connect(on_connect)
+
+            connect_params = {
+                "ns": f"/v1/user/{TEST_USER_ID}",
+                "accessToken": TEST_ACCESS_TOKEN,
+            }
+
+            await api.websocket.async_connect()
+            api.websocket._sio.eio.connect.mock.assert_called_once_with(
+                f"wss://api.simplisafe.com/socket.io?{urlencode(connect_params)}",
+                engineio_path="socket.io",
+                headers={},
+                transports=["websocket"],
+            )
+
+            await api.websocket._sio._trigger_event("connect", namespace="/")
+            on_connect.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_failure(event_loop, v3_server):
+    """Test connecting to the socket and an exception occurring."""
+    async with v3_server:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            api.websocket._sio.eio.connect = async_mock(side_effect=SocketIOError())
+
+        with pytest.raises(WebsocketError):
+            await api.websocket.async_connect()
+
+
+@pytest.mark.asyncio
+async def test_async_events(event_loop, v3_server):
+    """Test events with async handlers."""
+    async with v3_server:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            api.websocket._sio.eio._trigger_event = async_mock()
+            api.websocket._sio.eio.connect = async_mock()
+            api.websocket._sio.eio.disconnect = async_mock()
+
+            on_connect = async_mock()
+            on_disconnect = async_mock()
+            on_event = async_mock()
+
+            api.websocket.async_on_connect(on_connect)
+            api.websocket.async_on_disconnect(on_disconnect)
+            api.websocket.async_on_event(on_event)
+
+            connect_params = {
+                "ns": f"/v1/user/{TEST_USER_ID}",
+                "accessToken": TEST_ACCESS_TOKEN,
+            }
+
+            await api.websocket.async_connect()
+            api.websocket._sio.eio.connect.mock.assert_called_once_with(
+                f"wss://api.simplisafe.com/socket.io?{urlencode(connect_params)}",
+                engineio_path="socket.io",
+                headers={},
+                transports=["websocket"],
+            )
+
+            await api.websocket._sio._trigger_event("connect", namespace="/")
+            on_connect.mock.assert_called_once()
+
+            await api.websocket._sio._trigger_event(
+                "event", namespace=f"/v1/user/{TEST_USER_ID}"
+            )
+            on_event.mock.assert_called_once()
+
+            await api.websocket.async_disconnect()
+            await api.websocket._sio._trigger_event("disconnect", namespace="/")
+            api.websocket._sio.eio.disconnect.mock.assert_called_once_with(abort=True)
+            on_disconnect.mock.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_sync_events(event_loop, v3_server):
+    """Test events with synchronous handlers."""
+    async with v3_server:
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            api.websocket._sio.eio._trigger_event = async_mock()
+            api.websocket._sio.eio.connect = async_mock()
+            api.websocket._sio.eio.disconnect = async_mock()
+
+            on_connect = MagicMock()
+            on_disconnect = MagicMock()
+            on_event = MagicMock()
+
+            api.websocket.on_connect(on_connect)
+            api.websocket.on_disconnect(on_disconnect)
+            api.websocket.on_event(on_event)
+
+            connect_params = {
+                "ns": f"/v1/user/{TEST_USER_ID}",
+                "accessToken": TEST_ACCESS_TOKEN,
+            }
+
+            await api.websocket.async_connect()
+            api.websocket._sio.eio.connect.mock.assert_called_once_with(
+                f"wss://api.simplisafe.com/socket.io?{urlencode(connect_params)}",
+                engineio_path="socket.io",
+                headers={},
+                transports=["websocket"],
+            )
+
+            await api.websocket._sio._trigger_event("connect", namespace="/")
+            on_connect.assert_called_once()
+
+            await api.websocket._sio._trigger_event(
+                "event", namespace=f"/v1/user/{TEST_USER_ID}"
+            )
+            on_event.assert_called_once()
+
+            await api.websocket.async_disconnect()
+            await api.websocket._sio._trigger_event("disconnect", namespace="/")
+            api.websocket._sio.eio.disconnect.mock.assert_called_once_with(abort=True)
+            on_disconnect.assert_called_once()


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds experimental support for SimpliSafe's SocketIO-based websocket. Note that although the base functionality works, I cannot guarantee that this survives expired access tokens, etc.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/59
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
