### PR TITLE
Give all entities an update() coroutine

### DIFF
--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -5,13 +5,6 @@ Locks
 allows users to retrieve information on them and alter their state by
 locking/unlocking them.
 
-**NOTE:** Individual locks cannot be updated directly; instead, the ``update()``
-method on their parent ``System`` object should be used. It is crucial to remember
-that lock states are only as current as the last time ``system.update()`` was
-called. The only exception to this rule is when ``lock.lock()`` or
-``lock.unlock()`` are called; both of these will automatically update the lock
-state.
-
 Core Properties
 ---------------
 
@@ -78,3 +71,13 @@ Locking and unlocking a lock is accomplished via two coroutines:
     for serial, lock in system.locks.items():
         await lock.lock()
         await lock.unlock()
+
+
+Updating the Lock
+-----------------
+
+To retrieve the sensor's latest state/properties/etc., simply:
+
+.. code:: python
+
+    await lock.update()

--- a/docs/sensor.rst
+++ b/docs/sensor.rst
@@ -4,11 +4,6 @@ Sensors
 ``Sensor`` objects provide information about the SimpliSafe™ sensors to
 which they relate.
 
-**NOTE:** Individual sensors cannot be updated directly; instead,
-the ``update()`` method on their parent ``System`` object should be used. It is
-crucial to remember that sensor states are only as current as the last time
-``system.update()`` was called.
-
 Like their ``System`` cousins, two types of objects can be returned:
 
 * ``SensorV2``: an object to view V2 (classic) SimpliSafe™ sensors
@@ -61,31 +56,38 @@ V2 Properties
 
 .. code:: python
 
-    for serial, sensor in system.sensors.items():
-        # Return the sensor's data as a currently
-        # non-understood integer:
-        sensor.data
-        # >>> 0
+    # Return the sensor's data as a currently
+    # non-understood integer:
+    sensor.data
+    # >>> 0
 
-        # Return the sensor's settings as a currently
-        # non-understood integer:
-        sensor.settings
-        # >>> 1
+    # Return the sensor's settings as a currently
+    # non-understood integer:
+    sensor.settings
+    # >>> 1
 
 V3 Properties
 -------------
 
 .. code:: python
 
-    for serial, sensor in system.sensors.items():
-        # Return whether the sensor is offline:
-        sensor.offline
-        # >>> False
+    # Return whether the sensor is offline:
+    sensor.offline
+    # >>> False
 
-        # Return a settings dictionary for the sensor:
-        sensor.settings
-        # >>> {"instantTrigger": False, "away2": 1, "away": 1, ...}
+    # Return a settings dictionary for the sensor:
+    sensor.settings
+    # >>> {"instantTrigger": False, "away2": 1, "away": 1, ...}
 
-        # For temperature sensors, return the current temperature:
-        sensor.temperature
-        # >>> 67
+    # For temperature sensors, return the current temperature:
+    sensor.temperature
+    # >>> 67
+
+Updating the Sensor
+-------------------
+
+To retrieve the sensor's latest state/properties/etc., simply:
+
+.. code:: python
+
+    await sensor.update()

--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -58,9 +58,9 @@ class Entity:
         """Return the entity type."""
         return self._type
 
-    async def update(self, refresh_location: bool = True, cached: bool = True) -> None:
+    async def update(self, cached: bool = True) -> None:
         """Retrieve the latest state/properties for the entity."""
-        await self._system.update(refresh_location, cached)
+        await self._system.update_entities(cached)
 
 
 class EntityV3(Entity):

--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from simplipy.api import API
+    from simplipy.system import System
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -34,11 +35,11 @@ class Entity:
     """Define a base SimpliSafe entity."""
 
     def __init__(
-        self, api: "API", system_id: int, entity_type: EntityTypes, entity_data: dict
+        self, api: "API", system: "System", entity_type: EntityTypes, entity_data: dict
     ) -> None:
         """Initialize."""
         self._api: "API" = api
-        self._system_id: int = system_id
+        self._system: "System" = system
         self._type: EntityTypes = entity_type
         self.entity_data: dict = entity_data
 
@@ -56,6 +57,10 @@ class Entity:
     def type(self) -> EntityTypes:
         """Return the entity type."""
         return self._type
+
+    async def update(self, refresh_location: bool = True, cached: bool = True) -> None:
+        """Retrieve the latest state/properties for the entity."""
+        await self._system.update(refresh_location, cached)
 
 
 class EntityV3(Entity):

--- a/simplipy/lock.py
+++ b/simplipy/lock.py
@@ -60,7 +60,7 @@ class Lock(EntityV3):
         """Set the lock state."""
         await self._api.request(
             "post",
-            f"doorlock/{self._system_id}/{self.serial}/state",
+            f"doorlock/{self._system.system_id}/{self.serial}/state",
             json={"state": SET_STATE_MAP[state]},
         )
 

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -177,37 +177,6 @@ class System:
         """Raise if calling this undefined based method."""
         raise NotImplementedError()
 
-    async def _update_entities(self, cached: bool = True) -> None:
-        """Update sensors to the latest values."""
-        entities: dict = await self._get_entities_payload(cached)
-
-        _LOGGER.debug("Get entities response: %s", entities)
-
-        entity_data: dict
-        for entity_data in entities:
-            if not entity_data:
-                continue
-
-            try:
-                entity_type: EntityTypes = EntityTypes(entity_data["type"])
-            except ValueError:
-                _LOGGER.error("Unknown entity type: %s", entity_data["type"])
-                entity_type = EntityTypes.unknown
-
-            if entity_type == EntityTypes.lock:
-                prop = self.locks
-            else:
-                prop = self.sensors  # type: ignore
-
-            if entity_data["serial"] in prop:
-                entity = prop[entity_data["serial"]]
-                entity.entity_data = entity_data
-            else:
-                klass = get_entity_class(entity_type, version=self.version)
-                prop[entity_data["serial"]] = klass(  # type: ignore
-                    self.api, self, entity_type, entity_data
-                )
-
     async def _update_location_info(self) -> None:
         """Update information on the system."""
         subscription_resp: dict = await self.api.get_subscription_data()
@@ -317,7 +286,7 @@ class System:
     async def update(self, refresh_location: bool = True, cached: bool = True) -> None:
         """Update to the latest data (including entities)."""
         tasks: Dict[str, Coroutine] = {
-            "entities": self._update_entities(cached),
+            "entities": self.update_entities(cached),
             "settings": self._update_settings(cached),
         }
         if refresh_location:
@@ -334,3 +303,34 @@ class System:
                 raise result
             if isinstance(result, SimplipyError):
                 _LOGGER.error("Error while retrieving %s: %s", operation, result)
+
+    async def update_entities(self, cached: bool = True) -> None:
+        """Update sensors to the latest values."""
+        entities: dict = await self._get_entities_payload(cached)
+
+        _LOGGER.debug("Get entities response: %s", entities)
+
+        entity_data: dict
+        for entity_data in entities:
+            if not entity_data:
+                continue
+
+            try:
+                entity_type: EntityTypes = EntityTypes(entity_data["type"])
+            except ValueError:
+                _LOGGER.error("Unknown entity type: %s", entity_data["type"])
+                entity_type = EntityTypes.unknown
+
+            if entity_type == EntityTypes.lock:
+                prop = self.locks
+            else:
+                prop = self.sensors  # type: ignore
+
+            if entity_data["serial"] in prop:
+                entity = prop[entity_data["serial"]]
+                entity.entity_data = entity_data
+            else:
+                klass = get_entity_class(entity_type, version=self.version)
+                prop[entity_data["serial"]] = klass(  # type: ignore
+                    self.api, self, entity_type, entity_data
+                )

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -205,7 +205,7 @@ class System:
             else:
                 klass = get_entity_class(entity_type, version=self.version)
                 prop[entity_data["serial"]] = klass(  # type: ignore
-                    self.api, self.system_id, entity_type, entity_data
+                    self.api, self, entity_type, entity_data
                 )
 
     async def _update_location_info(self) -> None:

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -5,7 +5,6 @@ import aiohttp
 import pytest
 
 from simplipy import API
-from simplipy.entity import EntityTypes
 from simplipy.errors import InvalidCredentialsError
 from simplipy.lock import LockStates
 
@@ -17,6 +16,7 @@ from .const import (
     TEST_PASSWORD,
     TEST_SUBSCRIPTION_ID,
     TEST_SYSTEM_ID,
+    TEST_USER_ID,
 )
 from .fixtures import *
 from .fixtures.v2 import *
@@ -129,26 +129,6 @@ async def test_properties(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_properties(event_loop, v3_server):
-    """Test that lock properties are created properly."""
-    async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
-            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
-            systems = await api.get_systems()
-            system = systems[TEST_SYSTEM_ID]
-
-            lock = system.locks[TEST_LOCK_ID]
-            assert not lock.disabled
-            assert not lock.error
-            assert not lock.lock_low_battery
-            assert not lock.low_battery
-            assert not lock.offline
-            assert not lock.pin_pad_low_battery
-            assert not lock.pin_pad_offline
-            assert lock.state is LockStates.locked
-
-
-@pytest.mark.asyncio
 async def test_unknown_state(caplog, event_loop, v3_server):
     """Test handling a generic error during update."""
     async with v3_server:
@@ -161,3 +141,75 @@ async def test_unknown_state(caplog, event_loop, v3_server):
             assert lock.state == LockStates.unknown
 
             assert any("Unknown raw lock state" in e.message for e in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_update(
+    aresponses,
+    event_loop,
+    v3_lock_lock_response_json,
+    v3_lock_unlock_response_json,
+    v3_sensors_json,
+    v3_server,
+    v3_settings_json,
+    v3_subscriptions_json,
+):
+    """Test updating the lock."""
+    async with v3_server:
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/doorlock/{TEST_SUBSCRIPTION_ID}/{TEST_LOCK_ID}/state",
+            "post",
+            aresponses.Response(
+                text=json.dumps(v3_lock_unlock_response_json), status=200
+            ),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/doorlock/{TEST_SUBSCRIPTION_ID}/{TEST_LOCK_ID}/state",
+            "post",
+            aresponses.Response(
+                text=json.dumps(v3_lock_lock_response_json), status=200
+            ),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/users/{TEST_USER_ID}/subscriptions",
+            "get",
+            aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
+            "get",
+            aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            "get",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/doorlock/{TEST_SUBSCRIPTION_ID}/{TEST_LOCK_ID}/state",
+            "post",
+            aresponses.Response(
+                text=json.dumps(v3_lock_lock_response_json), status=200
+            ),
+        )
+
+        async with aiohttp.ClientSession(loop=event_loop) as websession:
+            api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            systems = await api.get_systems()
+            system = systems[TEST_SYSTEM_ID]
+
+            lock = system.locks[TEST_LOCK_ID]
+            assert lock.state == LockStates.locked
+
+            await lock.unlock()
+            assert lock.state == LockStates.unlocked
+
+            # Simulate a manual lock and an update some time later:
+            await lock.update()
+            assert lock.state == LockStates.locked

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -174,21 +174,9 @@ async def test_update(
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/users/{TEST_USER_ID}/subscriptions",
-            "get",
-            aresponses.Response(text=json.dumps(v3_subscriptions_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
             f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
             "get",
             aresponses.Response(text=json.dumps(v3_sensors_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
-            "get",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",


### PR DESCRIPTION
**Describe what the PR does:**

It's always been a tad awkward that sensors/locks couldn't request a state/property update – if you wanted to get the latest, you'd have to call `system.update()` (which updates _everything_ by default) and then go back to the sensor/lock. This PR adds an `update()` coroutine to all entities.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
