### PR TITLE
Cleanup/refactor of library

### DIFF
--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -80,4 +80,4 @@ To retrieve the sensor's latest state/properties/etc., simply:
 
 .. code:: python
 
-    await sensor.update(cached=True)
+    await lock.update(cached=True)

--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -80,4 +80,4 @@ To retrieve the sensor's latest state/properties/etc., simply:
 
 .. code:: python
 
-    await lock.update()
+    await sensor.update(cached=True)

--- a/docs/sensor.rst
+++ b/docs/sensor.rst
@@ -90,4 +90,4 @@ To retrieve the sensor's latest state/properties/etc., simply:
 
 .. code:: python
 
-    await sensor.update()
+    await sensor.update(cached=True)

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -168,15 +168,29 @@ additional properties:
     system.wifi_strength
     # >>> -43
 
-Refreshing the System
----------------------
+Getting the Latest System Info
+------------------------------
 
-Refreshing the ``System`` object, which gets the latest state, the latest sensor
-info, etc., is done via the ``update()`` coroutine:
+Refreshing the ``System`` object is done via the ``update()`` coroutine:
 
 .. code:: python
 
     await system.update()
+
+Note that this method can be supplied with four optional parameters (all of which
+default to ``True``):
+
+* ``include_system``: update the system state and properties
+* ``include_settings``: update system settings (like PINs)
+* ``include_entities``: update all sensors/locks/etc. associated with a system
+* ``cached``: use the last values provides by the base station
+
+For instance, if a user only wanted to update sensors and wanted to force a new data
+refresh:
+
+.. code:: python
+
+    await system.update(include_system=False, include_settings=False, cached=False)
 
 There are two crucial differences between V2 and V3 systems when updating:
 

--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -1,11 +1,7 @@
 """Define a base SimpliSafe entity."""
 from enum import Enum
 import logging
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from simplipy.api import API
-    from simplipy.system import System
+from typing import Callable, Coroutine
 
 _LOGGER: logging.Logger = logging.getLogger(__name__)
 
@@ -34,13 +30,19 @@ class EntityTypes(Enum):
 class Entity:
     """Define a base SimpliSafe entity."""
 
-    def __init__(
-        self, api: "API", system: "System", entity_type: EntityTypes, entity_data: dict
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        request: Callable[..., Coroutine],
+        update_func: Callable[..., Coroutine],
+        system_id: int,
+        entity_type: EntityTypes,
+        entity_data: dict,
     ) -> None:
         """Initialize."""
-        self._api: "API" = api
-        self._system: "System" = system
+        self._request: Callable[..., Coroutine] = request
+        self._system_id: int = system_id
         self._type: EntityTypes = entity_type
+        self._update_func: Callable[..., Coroutine] = update_func
         self.entity_data: dict = entity_data
 
     @property
@@ -60,7 +62,7 @@ class Entity:
 
     async def update(self, cached: bool = True) -> None:
         """Retrieve the latest state/properties for the entity."""
-        await self._system.update_entities(cached)
+        await self._update_func(cached)
 
 
 class EntityV3(Entity):

--- a/simplipy/lock.py
+++ b/simplipy/lock.py
@@ -58,9 +58,9 @@ class Lock(EntityV3):
 
     async def _set_lock_state(self, state: LockStates) -> None:
         """Set the lock state."""
-        await self._api.request(
+        await self._request(
             "post",
-            f"doorlock/{self._system.system_id}/{self.serial}/state",
+            f"doorlock/{self._system_id}/{self.serial}/state",
             json={"state": SET_STATE_MAP[state]},
         )
 

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -19,7 +19,7 @@ class SystemV2(System):
 
     async def _get_entities_payload(self, cached: bool = True) -> dict:
         """Update sensors to the latest values."""
-        sensor_resp = await self.api.request(
+        sensor_resp = await self._request(
             "get",
             f"subscriptions/{self.system_id}/settings",
             params={"settingsType": "all", "cached": str(cached).lower()},
@@ -29,7 +29,7 @@ class SystemV2(System):
 
     async def _send_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""
-        await self.api.request(
+        await self._request(
             "post",
             f"subscriptions/{self.system_id}/pins",
             json=create_pin_payload(pins, version=2),
@@ -37,7 +37,7 @@ class SystemV2(System):
 
     async def _set_state(self, value: Enum) -> None:
         """Set the state of the system."""
-        state_resp: dict = await self.api.request(
+        state_resp: dict = await self._request(
             "post",
             f"subscriptions/{self.system_id}/state",
             params={"state": value.name},
@@ -53,7 +53,7 @@ class SystemV2(System):
 
     async def get_pins(self, cached: bool = True) -> Dict[str, str]:
         """Return all of the set PINs, including master and duress."""
-        pins_resp: dict = await self.api.request(
+        pins_resp: dict = await self._request(
             "get",
             f"subscriptions/{self.system_id}/pins",
             params={"settingsType": "all", "cached": str(cached).lower()},

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,13 @@
+"""Define common test utilities."""
+from unittest.mock import MagicMock
+
+
+def async_mock(*args, **kwargs):
+    """Return a mock asynchronous function."""
+    mock = MagicMock(*args, **kwargs)
+
+    async def mock_coro(*args, **kwargs):
+        return mock(*args, **kwargs)
+
+    mock_coro.mock = mock
+    return mock_coro

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,4 +1,5 @@
 """Define tests for the Lock objects."""
+# pylint: disable=redefined-outer-name,unused-import
 import json
 
 import aiohttp
@@ -16,20 +17,26 @@ from .const import (
     TEST_PASSWORD,
     TEST_SUBSCRIPTION_ID,
     TEST_SYSTEM_ID,
-    TEST_USER_ID,
 )
-from .fixtures import *
-from .fixtures.v2 import *
-from .fixtures.v3 import *
+from .fixtures import (  # noqa
+    api_token_json,
+    auth_check_json,
+    invalid_credentials_json,
+    unavailable_feature_json,
+)
+from .fixtures.v3 import (  # noqa
+    v3_sensors_json,
+    v3_server,
+    v3_settings_json,
+    v3_subscriptions_json,
+    v3_lock_lock_response_json,
+    v3_lock_unlock_response_json,
+)
 
 
 @pytest.mark.asyncio
 async def test_lock_unlock(
-    aresponses,
-    event_loop,
-    v3_server,
-    v3_lock_lock_response_json,
-    v3_lock_unlock_response_json,
+    aresponses, v3_server, v3_lock_lock_response_json, v3_lock_unlock_response_json
 ):
     """Test locking the lock."""
     async with v3_server:
@@ -50,7 +57,7 @@ async def test_lock_unlock(
             ),
         )
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -66,10 +73,10 @@ async def test_lock_unlock(
 
 
 @pytest.mark.asyncio
-async def test_jammed(event_loop, v3_server):
+async def test_jammed(v3_server):
     """Test that a jammed lock shows the correct state."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -79,7 +86,7 @@ async def test_jammed(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_no_state_change_on_failure(aresponses, event_loop, v3_server):
+async def test_no_state_change_on_failure(aresponses, v3_server):
     """Test that the lock doesn't change state on error."""
     async with v3_server:
         v3_server.add(
@@ -95,7 +102,7 @@ async def test_no_state_change_on_failure(aresponses, event_loop, v3_server):
             aresponses.Response(text="", status=401),
         )
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -109,10 +116,10 @@ async def test_no_state_change_on_failure(aresponses, event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_properties(event_loop, v3_server):
+async def test_properties(v3_server):
     """Test that lock properties are created properly."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -129,10 +136,10 @@ async def test_properties(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_unknown_state(caplog, event_loop, v3_server):
+async def test_unknown_state(caplog, v3_server):
     """Test handling a generic error during update."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -144,15 +151,12 @@ async def test_unknown_state(caplog, event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_update(
+async def test_update(  # pylint: disable=too-many-arguments
     aresponses,
-    event_loop,
     v3_lock_lock_response_json,
     v3_lock_unlock_response_json,
     v3_sensors_json,
     v3_server,
-    v3_settings_json,
-    v3_subscriptions_json,
 ):
     """Test updating the lock."""
     async with v3_server:
@@ -187,7 +191,7 @@ async def test_update(
             ),
         )
 
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,4 +1,5 @@
 """Define tests for the Sensor objects."""
+# pylint: disable=redefined-outer-name,unused-import
 import aiohttp
 import pytest
 
@@ -7,16 +8,21 @@ from simplipy.entity import EntityTypes
 from simplipy.errors import SimplipyError
 
 from .const import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
-from .fixtures import *
-from .fixtures.v2 import *
-from .fixtures.v3 import *
+from .fixtures import api_token_json, auth_check_json  # noqa
+from .fixtures.v2 import v2_server, v2_settings_json, v2_subscriptions_json  # noqa
+from .fixtures.v3 import (  # noqa
+    v3_sensors_json,
+    v3_settings_json,
+    v3_server,
+    v3_subscriptions_json,
+)
 
 
 @pytest.mark.asyncio
-async def test_properties_base(event_loop, v2_server):
+async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -28,10 +34,10 @@ async def test_properties_base(event_loop, v2_server):
 
 
 @pytest.mark.asyncio
-async def test_properties_v2(event_loop, v2_server):
+async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -57,10 +63,10 @@ async def test_properties_v2(event_loop, v2_server):
 
 
 @pytest.mark.asyncio
-async def test_properties_v3(event_loop, v3_server):
+async def test_properties_v3(v3_server):
     """Test that v3 sensor properties are created properly."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             systems = await api.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -86,10 +92,10 @@ async def test_properties_v3(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_unknown_sensor_type(caplog, event_loop, v2_server):
+async def test_unknown_sensor_type(caplog, v2_server):
     """Test that a message is logged when unknown sensors types are found."""
     async with v2_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             _ = await api.get_systems()  # noqa
             assert any("Unknown" in e.message for e in caplog.records)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,35 +1,31 @@
 """Define tests for the Websocket API."""
-import aiohttp
-import pytest
-from unittest.mock import patch, MagicMock
+# pylint: disable=protected-access,redefined-outer-name,unused-import
+from unittest.mock import MagicMock
 from urllib.parse import urlencode
 
+import aiohttp
+import pytest
 from socketio.exceptions import SocketIOError
 
 from simplipy import API
 from simplipy.errors import WebsocketError
 
+from .common import async_mock
 from .const import TEST_ACCESS_TOKEN, TEST_EMAIL, TEST_PASSWORD, TEST_USER_ID
-from .fixtures import *  # noqa
-from .fixtures.v3 import *  # noqa
-
-
-def async_mock(*args, **kwargs):
-    """Return a mock asynchronous function."""
-    m = MagicMock(*args, **kwargs)
-
-    async def mock_coro(*args, **kwargs):
-        return m(*args, **kwargs)
-
-    mock_coro.mock = m
-    return mock_coro
+from .fixtures import api_token_json, auth_check_json  # noqa
+from .fixtures.v3 import (  # noqa
+    v3_sensors_json,
+    v3_settings_json,
+    v3_server,
+    v3_subscriptions_json,
+)
 
 
 @pytest.mark.asyncio
-async def test_connect_async_success(event_loop, v3_server):
+async def test_connect_async_success(v3_server):
     """Test triggering an async handler upon connection to the websocket."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             api.websocket._sio.eio._trigger_event = async_mock()
             api.websocket._sio.eio.connect = async_mock()
@@ -55,10 +51,10 @@ async def test_connect_async_success(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_connect_sync_success(event_loop, v3_server):
+async def test_connect_sync_success(v3_server):
     """Test triggering a synchronous handler upon connection to the websocket."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             api.websocket._sio.eio._trigger_event = async_mock()
             api.websocket._sio.eio.connect = async_mock()
@@ -84,10 +80,10 @@ async def test_connect_sync_success(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_connect_failure(event_loop, v3_server):
+async def test_connect_failure(v3_server):
     """Test connecting to the socket and an exception occurring."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             api.websocket._sio.eio.connect = async_mock(side_effect=SocketIOError())
 
@@ -96,10 +92,10 @@ async def test_connect_failure(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_async_events(event_loop, v3_server):
+async def test_async_events(v3_server):
     """Test events with async handlers."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             api.websocket._sio.eio._trigger_event = async_mock()
             api.websocket._sio.eio.connect = async_mock()
@@ -141,10 +137,10 @@ async def test_async_events(event_loop, v3_server):
 
 
 @pytest.mark.asyncio
-async def test_sync_events(event_loop, v3_server):
+async def test_sync_events(v3_server):
     """Test events with synchronous handlers."""
     async with v3_server:
-        async with aiohttp.ClientSession(loop=event_loop) as websession:
+        async with aiohttp.ClientSession() as websession:
             api = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
             api.websocket._sio.eio._trigger_event = async_mock()
             api.websocket._sio.eio.connect = async_mock()


### PR DESCRIPTION
**Describe what the PR does:**

This is probably too huge, but it's been a heck of a day and my "caring" is low. 😆

This PR is a catch-all to clean up several issues that I had with the library:

 * Streamlined dependency injection from `API` object into `System`, etc. – no more passing the entire API object.
* `system.update()` now has separate parameters for what should be included (system, settings, entities).
* Cleaned up/normalized several method names.
* Cleaned up a lot of the linting issues in the tests.
* Removed the soon-to-be-deprecated `event_loop` fixture in all tests.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
