### PR TITLE
Change generic "settings" call to be more specific

### DIFF
--- a/docs/system.rst
+++ b/docs/system.rst
@@ -176,8 +176,8 @@ Note that this method can be supplied with four optional parameters (all of whic
 default to ``True``):
 
 * ``include_system``: update the system state and properties
-* ``include_settings``: update system settings (like PINs)
 * ``include_entities``: update all sensors/locks/etc. associated with a system
+* ``include_pins``: update system settings (like PINs)
 * ``cached``: use the last values provides by the base station
 
 For instance, if a user only wanted to update sensors and wanted to force a new data

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -242,7 +242,7 @@ class System:
         """Return the current sensor payload."""
         raise NotImplementedError()
 
-    async def _get_settings(self, cached: bool = True) -> None:
+    async def _get_pins(self, cached: bool = True) -> None:
         """Update system settings."""
         pass
 
@@ -390,8 +390,8 @@ class System:
         self,
         *,
         include_system: bool = True,
-        include_settings: bool = True,
         include_entities: bool = True,
+        include_pins: bool = True,
         cached: bool = True,
     ) -> None:
         """Get the latest system data.
@@ -401,18 +401,18 @@ class System:
 
         :param include_system: Whether system state/properties should be updated
         :type include_system: ``bool``
-        :param include_settings: Whether system settings (like PINs) should be updated
-        :type include_settings: ``bool``
         :param include_entities: Whether sensors/locks/etc. should be updated
         :type include_entities: ``bool``
+        :param include_pins: Whether system settings (like PINs) should be updated
+        :type include_pins: ``bool``
         :param cached: Whether to used cached data.
         :type cached: ``bool``
         """
         tasks: Dict[str, Coroutine] = {}
         if include_system:
             tasks["system"] = self._get_system_info()
-        if include_settings:
-            tasks["settings"] = self._get_settings(cached)
+        if include_pins:
+            tasks["pin"] = self._get_pins(cached)
         if include_entities:
             tasks["entity"] = self._get_entities(cached)
 

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -154,7 +154,7 @@ class SystemV3(System):
 
         return sensor_resp["sensors"]
 
-    async def _get_settings(self, cached: bool = True) -> None:
+    async def _get_pins(self, cached: bool = True) -> None:
         """Update system settings."""
         settings_resp: dict = await self._request(
             "get",
@@ -196,7 +196,7 @@ class SystemV3(System):
         :type cached: ``bool``
         :rtype: ``Dict[str, str]``
         """
-        await self._get_settings(cached)
+        await self._get_pins(cached)
 
         pins: Dict[str, str] = {
             CONF_MASTER_PIN: self._settings_info["settings"]["pins"]["master"]["pin"],

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -873,6 +873,6 @@ async def test_update_error_v3(  # pylint: disable=too-many-arguments
             await system.update()
 
             assert any(
-                "Error while getting latest settings values" in e.message
+                "Error while getting latest pin values" in e.message
                 for e in caplog.records
             )


### PR DESCRIPTION
**Describe what the PR does:**

This PR changes some private method names to be more consistent with the results they return.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)