### PR TITLE
Add new property and property setter methods to V3 systems

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,6 +31,13 @@ API Reference
 .. autoclass:: simplipy.entity.EntityV3
    :members:
 
+``LevelMap (V3)``
+---------------------
+
+.. autoclass:: simplipy.system.v3.LevelMap
+   :members:
+   :undoc-members:
+
 ``Lock``
 --------------------
 

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -158,7 +158,7 @@ class SystemV3(System):
         """Get all system settings."""
         settings_resp: dict = await self._request(
             "get",
-            f"ss3/subscriptions/{self.system_id}/settings/pins",
+            f"ss3/subscriptions/{self.system_id}/settings/normal",
             params={"forceUpdate": str(not cached).lower()},
         )
 

--- a/tests/fixtures/v3.py
+++ b/tests/fixtures/v3.py
@@ -53,7 +53,7 @@ def v3_server(
     )
     server.add(
         "api.simplisafe.com",
-        f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+        f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
         "get",
         aresponses.Response(text=json.dumps(v3_settings_json), status=200),
     )
@@ -673,7 +673,7 @@ def v3_settings_deleted_pin_json():
 
 @pytest.fixture()
 def v3_settings_json():
-    """Return a /v1/ss3/subscriptions/<SUBSCRIPTION_ID>/settings/pins."""
+    """Return a /v1/ss3/subscriptions/<SUBSCRIPTION_ID>/settings/normal."""
     return {
         "account": "12345012",
         "settings": {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -335,7 +335,7 @@ async def test_unavailable_feature_v3(  # pylint: disable=too-many-arguments
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -129,7 +129,7 @@ async def test_get_pins_v3(v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -247,7 +247,7 @@ async def test_get_systems_v3(  # pylint: disable=too-many-arguments
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -315,7 +315,7 @@ async def test_remove_nonexistent_pin_v3(v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -338,13 +338,13 @@ async def test_remove_pin_v3(v3_server, v3_settings_json, v3_settings_deleted_pi
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -358,7 +358,7 @@ async def test_remove_pin_v3(v3_server, v3_settings_json, v3_settings_deleted_pi
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(
                 text=json.dumps(v3_settings_deleted_pin_json), status=200
@@ -386,7 +386,7 @@ async def test_remove_reserved_pin_v3(v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -409,7 +409,7 @@ async def test_set_duplicate_pin(v3_server, v3_settings_json):
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -491,7 +491,7 @@ async def test_set_max_user_pins(
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(
                 text=json.dumps(v3_settings_full_pins_json), status=200
@@ -566,13 +566,13 @@ async def test_set_pin_v3(v3_server, v3_settings_json, v3_settings_new_pin_json)
     async with v3_server:
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -584,7 +584,7 @@ async def test_set_pin_v3(v3_server, v3_settings_json, v3_settings_new_pin_json)
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_new_pin_json), status=200),
         )
@@ -818,7 +818,7 @@ async def test_update_system_data_v3(
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
@@ -858,7 +858,7 @@ async def test_update_error_v3(  # pylint: disable=too-many-arguments
         )
         v3_server.add(
             "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/pins",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
             "get",
             aresponses.Response(text=json.dumps(v3_settings_json), status=500),
         )

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -9,6 +9,7 @@ import pytest
 from simplipy import API
 from simplipy.errors import InvalidCredentialsError, PinError
 from simplipy.system import System, SystemStates
+from simplipy.system.v3 import LevelMap as V3LevelMap
 
 from .common import async_mock
 from .const import (
@@ -465,7 +466,7 @@ async def test_properties_v3(v3_server):
             system = systems[TEST_SYSTEM_ID]
 
             assert system.alarm_duration == 240
-            assert system.alarm_volume == 3
+            assert system.alarm_volume == V3LevelMap.high
             assert system.battery_backup_power_level == 5293
             assert system.connection_type == "wifi"
             assert system.entry_delay_away == 30
@@ -477,7 +478,7 @@ async def test_properties_v3(v3_server):
             assert system.offline is False
             assert system.power_outage is False
             assert system.rf_jamming is False
-            assert system.voice_prompt_volume == 2
+            assert system.voice_prompt_volume == V3LevelMap.medium
             assert system.wall_power_level == 5933
             assert system.wifi_ssid == "MY_WIFI"
             assert system.wifi_strength == -49

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -455,9 +455,64 @@ async def test_properties(v2_server):
 
 
 @pytest.mark.asyncio
-async def test_properties_v3(v3_server):
+async def test_properties_v3(v3_server, v3_settings_json):
     """Test that v3 system properties are available."""
     async with v3_server:
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+
         async with aiohttp.ClientSession() as websession:
             simplisafe = await API.login_via_credentials(
                 TEST_EMAIL, TEST_PASSWORD, websession
@@ -468,6 +523,7 @@ async def test_properties_v3(v3_server):
             assert system.alarm_duration == 240
             assert system.alarm_volume == V3LevelMap.high
             assert system.battery_backup_power_level == 5293
+            assert system.chime_volume == V3LevelMap.medium
             assert system.connection_type == "wifi"
             assert system.entry_delay_away == 30
             assert system.entry_delay_home == 30
@@ -482,6 +538,44 @@ async def test_properties_v3(v3_server):
             assert system.wall_power_level == 5933
             assert system.wifi_ssid == "MY_WIFI"
             assert system.wifi_strength == -49
+
+            # Test "setting" various system properties by overriding their values, then
+            # calling the update functions:
+            system._settings_info["settings"]["normal"]["alarmDuration"] = 0
+            await system.set_alarm_duration(240)
+            assert system.alarm_duration == 240
+
+            system._settings_info["settings"]["normal"]["alarmVolume"] = 0
+            await system.set_alarm_volume(V3LevelMap.high)
+            assert system.alarm_volume == V3LevelMap.high
+
+            system._settings_info["settings"]["normal"]["doorChime"] = 0
+            await system.set_chime_volume(V3LevelMap.medium)
+            assert system.chime_volume == V3LevelMap.medium
+
+            system._settings_info["settings"]["normal"]["entryDelayAway"] = 0
+            await system.set_entry_delay_away(30)
+            assert system.entry_delay_away == 30
+
+            system._settings_info["settings"]["normal"]["entryDelayHome"] = 0
+            await system.set_entry_delay_home(30)
+            assert system.entry_delay_home == 30
+
+            system._settings_info["settings"]["normal"]["exitDelayAway"] = 0
+            await system.set_exit_delay_away(60)
+            assert system.exit_delay_away == 60
+
+            system._settings_info["settings"]["normal"]["exitDelayHome"] = 1000
+            await system.set_exit_delay_home(0)
+            assert system.exit_delay_home == 0
+
+            system._settings_info["settings"]["normal"]["light"] = False
+            await system.set_light(True)
+            assert system.exit_delay_home == 0
+
+            system._settings_info["settings"]["normal"]["voicePrompts"] = 0
+            await system.set_voice_prompt_volume(V3LevelMap.medium)
+            assert system.voice_prompt_volume == V3LevelMap.medium
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new V3 system property (`chime_volume`) and several methods to set V3 properties on the system itself. Note that although some of this functionality is also available for V2 systems, I'm electing to not implement it at this time:

* At some point, I need to start focusing on the future, which is going to be with V3 systems.
* The V3 API is clearer on things like setting volumes; whereas its API payloads are easier to understand (`0` for `off`, `1` for `low`, etc.), the V2 API isn't clear at all (no `off`, `25` for `low`, `35` for `medium`, etc.).

I'll re-evaluate this as the need arises.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
