### PR TITLE
Fix concurrency bug on system.update()

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -205,6 +205,15 @@ class System:
 
     async def _get_entities(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""
+        if not cached:
+            # Since this method is scheduled as a task in system.update(), it's possible
+            # that the loop will attempt to execute it before other SimpliSafe cloud
+            # resources are ready; if that occurs and we're asking for the latest values
+            # from the base station, it's possible the SimpliSafe cloud will return a
+            # 409. To protect against that, if we're asking for fresh values, we sleep 1
+            # first:
+            await asyncio.sleep(1)
+
         entities: dict = await self._get_entities_payload(cached)
 
         _LOGGER.debug("Get entities response: %s", entities)

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -25,7 +25,7 @@ class SystemV2(System):
             params={"settingsType": "all", "cached": str(cached).lower()},
         )
 
-        return sensor_resp["settings"]["sensors"]
+        return sensor_resp.get("settings", {}).get("sensors", [])
 
     async def _set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -169,7 +169,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
             params={"forceUpdate": str(not cached).lower()},
         )
 
-        return sensor_resp["sensors"]
+        return sensor_resp.get("sensors", [])
 
     async def _get_settings(self, cached: bool = True) -> None:
         """Get all system settings."""


### PR DESCRIPTION
**Describe what the PR does:**

In https://github.com/bachya/simplisafe-python/pull/69, I changed `system.update()` so that you could update system info, settings info, and sensor info independently. I did this by scheduling each API call as an `asyncio` task (for speed and concurrency); however, this introduced the possibility that the call to update sensor info would occur "too early" (a loose definition, as I'm not exactly sure _when_ that would be). In these cases, the SimpliSafe cloud would return an error:

```
Error requesting data from ss3/subscriptions/323864/sensors: 409, message='Conflict', url=URL('https://api.simplisafe.com/v1/ss3/subscriptions/323864/sensors?forceUpdate=true'
```

To address this possibility (and based on this [SO idea](https://stackoverflow.com/a/54670245)), this PR removes entity updating from the concurrent task pool and awaits it after the other tasks are done.

**Does this fix a specific issue?**

Fixes #73
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
