### PR TITLE
Add "doorbell" as a valid sensor type

### DIFF
--- a/simplipy/entity.py
+++ b/simplipy/entity.py
@@ -22,6 +22,7 @@ class EntityTypes(Enum):
     temperature = 10
     camera = 12
     siren = 13
+    doorbell = 15
     lock = 16
     lock_keypad = 253
     unknown = 99


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds doorbells as a valid sensor type. Note that it does not actually do anything _with_ doorbells, camera streams, etc. – it just allows doorbell "types" to be recognized.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Run tests and ensure 100% code coverage: `make coverage` (after running `make init`)
- [x] Ensure you have no linting errors: `make lint` (after running `make init`)
- [x] Ensure you have typed your code correctly: `make typing` (after running `make init`)
