### PR TITLE
Consolidate system property methods into one

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -31,13 +31,6 @@ API Reference
 .. autoclass:: simplipy.entity.EntityV3
    :members:
 
-``LevelMap (V3)``
----------------------
-
-.. autoclass:: simplipy.system.v3.LevelMap
-   :members:
-   :undoc-members:
-
 ``Lock``
 --------------------
 

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -163,19 +163,39 @@ additional properties:
     system.wifi_strength
     # >>> -43
 
-V3 systems also come with several methods to set several of these properties:
+V3 systems also come with a ``set_properties`` method to update the following system
+properties:
+
+* ``alarm_duration`` (in seconds): 30-480
+* ``alarm_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
+* ``chime_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
+* ``entry_delay_away`` (in seconds): 30-255
+* ``entry_delay_home`` (in seconds): 0-255
+* ``exit_delay_away`` (in seconds): 45-255
+* ``exit_delay_home`` (in seconds): 0-255
+* ``light``: True or False
+* ``voice_prompt_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
+
+Note that volume properties can accept integers or constants defined in
+``simplipy.system.v3``.
 
 .. code:: python
 
-    await system.set_alarm_duration(120)
-    await system.set_alarm_volume(simplipy.system.v3.LevelMap.medium)
-    await system.set_chime_volume(simplipy.system.v3.LevelMap.low)
-    await system.set_entry_delay_away(20)
-    await system.set_entry_delay_home(10)
-    await system.set_exit_delay_away(35)
-    await system.set_exit_delay_home(40)
-    await system.set_light(True)
-    await system.set_voice_prompt_volume(simplipy.system.v3.LevelMap.off)
+    from simplipy.system.v3 import VOLUME_OFF, VOLUME_LOW, VOLUME_MEDIUM
+
+    await system.set_properties(
+        {
+            "alarm_duration": 240,
+            "alarm_volume": VOLUME_HIGH,
+            "chime_volume": VOLUME_MEDIUM,
+            "entry_delay_away": 30,
+            "entry_delay_home": 30,
+            "exit_delay_away": 60,
+            "exit_delay_home": 0,
+            "light": True,
+            "voice_prompt_volume": VOLUME_MEDIUM,
+        }
+    )
 
 Note that ``system.set_exit_delay_away()``, ``system.set_exit_delay_home()``,
 ``system.set_exit_delay_away()``, and ``system.set_exit_delay_away()``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ aiohttp = "^3.6.2"
 python = "^3.6.1"
 python-engineio = ">= 3.9.3"
 python-socketio = ">=4.3.1"
+voluptuous = "^0.11.7"
 websockets = "^8.1"
 
 [tool.poetry.dev-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,3 +6,4 @@ pytest-cov==2.8.1
 pytest==5.3.2
 python-engineio==3.11.1
 python-socketio==4.4.0
+voluptuous == 0.11.7

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -9,7 +9,7 @@ import pytest
 from simplipy import API
 from simplipy.errors import InvalidCredentialsError, PinError, SimplipyError
 from simplipy.system import System, SystemStates
-from simplipy.system.v3 import LevelMap as V3LevelMap
+from simplipy.system.v3 import VOLUME_HIGH, VOLUME_MEDIUM
 
 from .common import async_mock
 from .const import (
@@ -459,54 +459,6 @@ async def test_properties_v3(v3_server, v3_settings_json):
             "post",
             aresponses.Response(text=json.dumps(v3_settings_json), status=200),
         )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "post",
-            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
-        )
 
         async with aiohttp.ClientSession() as websession:
             simplisafe = await API.login_via_credentials(
@@ -516,9 +468,9 @@ async def test_properties_v3(v3_server, v3_settings_json):
             system = systems[TEST_SYSTEM_ID]
 
             assert system.alarm_duration == 240
-            assert system.alarm_volume == V3LevelMap.high
+            assert system.alarm_volume == VOLUME_HIGH
             assert system.battery_backup_power_level == 5293
-            assert system.chime_volume == V3LevelMap.medium
+            assert system.chime_volume == VOLUME_MEDIUM
             assert system.connection_type == "wifi"
             assert system.entry_delay_away == 30
             assert system.entry_delay_home == 30
@@ -529,7 +481,7 @@ async def test_properties_v3(v3_server, v3_settings_json):
             assert system.offline is False
             assert system.power_outage is False
             assert system.rf_jamming is False
-            assert system.voice_prompt_volume == V3LevelMap.medium
+            assert system.voice_prompt_volume == VOLUME_MEDIUM
             assert system.wall_power_level == 5933
             assert system.wifi_ssid == "MY_WIFI"
             assert system.wifi_strength == -49
@@ -537,46 +489,50 @@ async def test_properties_v3(v3_server, v3_settings_json):
             # Test "setting" various system properties by overriding their values, then
             # calling the update functions:
             system._settings_info["settings"]["normal"]["alarmDuration"] = 0
-            await system.set_alarm_duration(240)
-            assert system.alarm_duration == 240
-
             system._settings_info["settings"]["normal"]["alarmVolume"] = 0
-            await system.set_alarm_volume(V3LevelMap.high)
-            assert system.alarm_volume == V3LevelMap.high
-
             system._settings_info["settings"]["normal"]["doorChime"] = 0
-            await system.set_chime_volume(V3LevelMap.medium)
-            assert system.chime_volume == V3LevelMap.medium
-
             system._settings_info["settings"]["normal"]["entryDelayAway"] = 0
-            await system.set_entry_delay_away(30)
-            assert system.entry_delay_away == 30
-
             system._settings_info["settings"]["normal"]["entryDelayHome"] = 0
-            await system.set_entry_delay_home(30)
-            assert system.entry_delay_home == 30
-
             system._settings_info["settings"]["normal"]["exitDelayAway"] = 0
-            await system.set_exit_delay_away(60)
-            assert system.exit_delay_away == 60
-
             system._settings_info["settings"]["normal"]["exitDelayHome"] = 1000
-            await system.set_exit_delay_home(0)
-            assert system.exit_delay_home == 0
-
             system._settings_info["settings"]["normal"]["light"] = False
-            await system.set_light(True)
-            assert system.exit_delay_home == 0
-
             system._settings_info["settings"]["normal"]["voicePrompts"] = 0
-            await system.set_voice_prompt_volume(V3LevelMap.medium)
-            assert system.voice_prompt_volume == V3LevelMap.medium
+
+            await system.set_properties(
+                {
+                    "alarm_duration": 240,
+                    "alarm_volume": VOLUME_HIGH,
+                    "chime_volume": VOLUME_MEDIUM,
+                    "entry_delay_away": 30,
+                    "entry_delay_home": 30,
+                    "exit_delay_away": 60,
+                    "exit_delay_home": 0,
+                    "light": True,
+                    "voice_prompt_volume": VOLUME_MEDIUM,
+                }
+            )
+            assert system.alarm_duration == 240
+            assert system.alarm_volume == VOLUME_HIGH
+            assert system.chime_volume == VOLUME_MEDIUM
+            assert system.entry_delay_away == 30
+            assert system.entry_delay_home == 30
+            assert system.exit_delay_away == 60
+            assert system.exit_delay_home == 0
+            assert system.light is True
+            assert system.voice_prompt_volume == VOLUME_MEDIUM
 
 
 @pytest.mark.asyncio
-async def test_delay_property_outside_limits(v3_server):
-    """Test that an error is raised when a delay param is given a value outside limit."""
+async def test_setting_invalid_property(v3_server, v3_settings_json):
+    """Test that setting an invalid property raises a ValueError."""
     async with v3_server:
+        v3_server.add(
+            "api.simplisafe.com",
+            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
+            "post",
+            aresponses.Response(text=json.dumps(v3_settings_json), status=200),
+        )
+
         async with aiohttp.ClientSession() as websession:
             simplisafe = await API.login_via_credentials(
                 TEST_EMAIL, TEST_PASSWORD, websession
@@ -584,8 +540,8 @@ async def test_delay_property_outside_limits(v3_server):
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
 
-            with pytest.raises(SimplipyError):
-                await system.set_exit_delay_home(1000)
+            with pytest.raises(ValueError):
+                await system.set_properties({"Fake": "News"})
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

While experimenting with the various system property methods (`set_chime_volume`, etc.), I came to a realization: because SimpliSafe's cloud API anticipates receiving updated property values all at once, our method (sending properties one at a time) can result in failed updates if those calls happen too close together. So, this PR scraps those methods in favor of a single `set_properties` method that updates everything at once.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
