### PR TITLE
Address possibility of instant-trigger parameter missing

### DIFF
--- a/simplipy/sensor/v3.py
+++ b/simplipy/sensor/v3.py
@@ -20,7 +20,7 @@ class SensorV3(EntityV3):
 
         :rtype: ``bool``
         """
-        return self.entity_data["setting"]["instantTrigger"]
+        return self.entity_data["setting"].get("instantTrigger", False)
 
     @property
     def triggered(self) -> bool:


### PR DESCRIPTION
**Describe what the PR does:**

Apparently, not all sensors have the `instantTrigger` key in their settings; accessing one that doesn't exist throws an exception. This PR addresses that.

**Does this fix a specific issue?**

N/A