### PR TITLE
Add helper to determine websocket event types

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -107,6 +107,6 @@ API Reference
 
 ``Websocket``
 -----------------------
-
+.. autofunction:: simplipy.websocket.get_event_type_from_payload
 .. autoclass:: simplipy.websocket.Websocket
    :members:

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -145,3 +145,26 @@ with this value:
       "videoStartedBy": "",
       "video": {}
     }
+
+``simplisafe-python`` provides a helper to determine the type of websocket event
+represented by the ``data`` argument:
+
+.. code:: python
+
+    from simplipy.websocket import get_event_type_from_payload
+
+    def event_handler(data):
+        print(f"Event type: {get_event_type_from_payload(data)}")
+
+    simplisafe.websocket.on_event(event_handler)
+
+This helper will return one of the following values:
+
+* ``armed_away``
+* ``armed_home``
+* ``arming``
+* ``automatic_test``
+* ``disarmed``
+* ``entry_detected``
+* ``sensor_error``
+* ``sensor_restored``

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -37,7 +37,22 @@ EVENT_MAPPING = {
 
 
 def get_event_type_from_payload(payload: dict) -> Optional[str]:
-    """Get the named websocket event from an event JSON payload."""
+    """Get the named websocket event from an event JSON payload.
+
+    The ``payload`` parameter of this method should be the ``data`` parameter provided
+    to any function or coroutine that is passed to
+    :meth:`simplipy.websocket.Websocket.on_event`.
+
+    Returns one of the following:
+        * ``armed_away``
+        * ``armed_home``
+        * ``arming``
+        * ``automatic_test``
+        * ``disarmed``
+        * ``entry_detected``
+        * ``sensor_error``
+        * ``sensor_restored``
+    """
     event_cid = payload["eventCid"]
 
     if event_cid not in EVENT_MAPPING:

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -1,4 +1,5 @@
 """Define a connection to the SimpliSafe websocket."""
+import logging
 from typing import Awaitable, Callable, Optional
 from urllib.parse import urlencode
 
@@ -7,7 +8,48 @@ from socketio.exceptions import ConnectionError as ConnError, SocketIOError
 
 from simplipy.errors import WebsocketError
 
+_LOGGER = logging.getLogger(__name__)
+
 API_URL_BASE: str = "wss://api.simplisafe.com/socket.io"
+
+EVENT_AUTOMATIC_TEST = "automatic_test"
+EVENT_SENSOR_ENTRY_DETECTED = "entry_detected"
+EVENT_SENSOR_ERROR = "sensor_error"
+EVENT_SENSOR_RESTORED = "sensor_restored"
+EVENT_SYSTEM_ARMED_AWAY = "armed_away"
+EVENT_SYSTEM_ARMED_HOME = "armed_home"
+EVENT_SYSTEM_ARMING = "arming"
+EVENT_SYSTEM_DISARMED = "disarmed"
+
+EVENT_MAPPING = {
+    1381: EVENT_SENSOR_ERROR,
+    1400: EVENT_SYSTEM_DISARMED,
+    1407: EVENT_SYSTEM_DISARMED,
+    1429: EVENT_SENSOR_ENTRY_DETECTED,
+    1602: EVENT_AUTOMATIC_TEST,
+    3381: EVENT_SENSOR_RESTORED,
+    3401: EVENT_SYSTEM_ARMED_AWAY,
+    3407: EVENT_SYSTEM_ARMED_AWAY,
+    3441: EVENT_SYSTEM_ARMED_HOME,
+    9401: EVENT_SYSTEM_ARMING,
+    9407: EVENT_SYSTEM_ARMING,
+}
+
+
+def get_event_type_from_payload(payload: dict) -> Optional[str]:
+    """Get the named websocket event from an event JSON payload."""
+    event_cid = payload["eventCid"]
+
+    if event_cid not in EVENT_MAPPING:
+        _LOGGER.warning(
+            'Encountered unknown websocket event type: %s ("%s"). Please report it at'
+            "https://github.com/bachya/simplisafe-python/issues.",
+            event_cid,
+            payload["info"],
+        )
+        return None
+
+    return EVENT_MAPPING[event_cid]
 
 
 class Websocket:

--- a/tests/const.py
+++ b/tests/const.py
@@ -12,3 +12,47 @@ TEST_SUBSCRIPTION_ID = 12345
 TEST_SYSTEM_ID = 12345
 TEST_SYSTEM_SERIAL_NO = "1234ABCD"
 TEST_USER_ID = 12345
+
+RESPONSE_WEBSOCKET_KNOWN_EVENT = {
+    "eventId": "xxxxxxxxxxxxx",
+    "eventTimestamp": "xxxxxxxxxxxxx",
+    "eventCid": 1400,
+    "zoneCid": "1",
+    "sensorType": 1,
+    "sensorSerial": "xxxxx",
+    "account": "xxxxx",
+    "userId": "xxxxxxx",
+    "sid": "xxxxxxx",
+    "info": "System Disarmed by Master PIN",
+    "pinName": "Master PIN",
+    "sensorName": "Garage Keypad",
+    "messageSubject": "SimpliSafe System Disarmed",
+    "messageBody": "System Disarmed: Your SimpliSafe security system was disarmed.",
+    "eventType": "activity",
+    "timezone": 2,
+    "locationOffset": -420,
+    "videoStartedBy": "",
+    "video": {},
+}
+
+RESPONSE_WEBSOCKET_UNKNOWN_EVENT = {
+    "eventId": 1231231231,
+    "eventTimestamp": 1231231231,
+    "eventCid": 1231,
+    "zoneCid": "3",
+    "sensorType": 0,
+    "sensorSerial": "",
+    "account": "xxxxxxxx",
+    "userId": 123123,
+    "sid": 123123,
+    "info": "System Went Totally Nuts!",
+    "pinName": "",
+    "sensorName": "",
+    "messageSubject": "SimpliSafe System Armed (home mode)",
+    "messageBody": "System Armed (home mode)",
+    "eventType": "activity",
+    "timezone": 2,
+    "locationOffset": -420,
+    "videoStartedBy": "",
+    "video": {},
+}

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -9,9 +9,17 @@ from socketio.exceptions import SocketIOError
 
 from simplipy import API
 from simplipy.errors import WebsocketError
+from simplipy.websocket import get_event_type_from_payload
 
 from .common import async_mock
-from .const import TEST_ACCESS_TOKEN, TEST_EMAIL, TEST_PASSWORD, TEST_USER_ID
+from .const import (
+    RESPONSE_WEBSOCKET_KNOWN_EVENT,
+    RESPONSE_WEBSOCKET_UNKNOWN_EVENT,
+    TEST_ACCESS_TOKEN,
+    TEST_EMAIL,
+    TEST_PASSWORD,
+    TEST_USER_ID,
+)
 from .fixtures import api_token_json, auth_check_json
 from .fixtures.v3 import (
     v3_sensors_json,
@@ -146,6 +154,15 @@ async def test_async_events(v3_server):
                 abort=True
             )
             on_disconnect.mock.assert_called_once()
+
+
+def test_event_types(caplog):
+    """Test appropriate responses to known and unknown websocket event types."""
+    event_type = get_event_type_from_payload(RESPONSE_WEBSOCKET_KNOWN_EVENT)
+    assert event_type == "disarmed"
+
+    get_event_type_from_payload(RESPONSE_WEBSOCKET_UNKNOWN_EVENT)
+    assert any("unknown websocket event type" in e.message for e in caplog.records)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a helper method to get the "type" of a websocket event: `simplipy.websocket.get_event_type_from_payload`. It takes a single `dict` that should be the value returned to any function/coroutine registered with `simplipy.websocket.Websocket.on_event`.

The result will be one of:

* `armed_away`
* `armed_home`
* `arming`
* `automatic_test`
* `disarmed`
* `entry_detected`
* `sensor_error`
* `sensor_restored`

...and will log a warning (inviting the user to create an issue here) if the event type is unknown.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
