### PR TITLE
Don't swallow errors during update

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -422,9 +422,7 @@ class System:
         result: dict
         for operation, result in zip(tasks, results):
             if isinstance(result, SimplipyError):
-                _LOGGER.error(
-                    "Error while getting latest %s values: %s", operation, result
-                )
+                raise result
 
         # We await entity updates after the task pool since including it can cause
         # HTTP 409s if that update occurs out of sequence:

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -901,7 +901,7 @@ async def test_update_system_data_v3(
 
 @pytest.mark.asyncio
 async def test_update_error_v3(  # pylint: disable=too-many-arguments
-    caplog, v3_server, v3_sensors_json, v3_settings_json, v3_subscriptions_json
+    v3_server, v3_sensors_json, v3_settings_json, v3_subscriptions_json
 ):
     """Test handling a generic error during update."""
     async with v3_server:
@@ -931,9 +931,5 @@ async def test_update_error_v3(  # pylint: disable=too-many-arguments
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
 
-            await system.update()
-
-            assert any(
-                "Error while getting latest settings values" in e.message
-                for e in caplog.records
-            )
+            with pytest.raises(SimplipyError):
+                await system.update()


### PR DESCRIPTION
**Describe what the PR does:**

`system.async_update()` executes multiple tasks in parallel. Until now, it swallowed exceptions and just logged errors. I realize that's bad: at the first sign of an error, it should re-raise that exception. This PR does that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.