### PR TITLE
Change type of "from" parameter in system.get_events()

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -1,8 +1,9 @@
 """Define V2 and V3 SimpliSafe systems."""
 import asyncio
+from datetime import datetime
 from enum import Enum
 import logging
-from typing import Any, Callable, Coroutine, Dict, List, Set, Type, Union
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Set, Type, Union
 
 from simplipy.entity import Entity, EntityTypes
 from simplipy.errors import PinError, SimplipyError
@@ -271,21 +272,21 @@ class System:
         raise NotImplementedError()
 
     async def get_events(
-        self, from_timestamp: int = None, num_events: int = None
+        self, from_datetime: Optional[datetime] = None, num_events: Optional[int] = None
     ) -> list:
         """Get events recorded by the base station.
 
         If no parameters are provided, this will return the most recent 50 events.
 
-        :param from_timestamp: The starting timestamp (if desired)
-        :type from_timestamp: ``int``
+        :param from_datetime: The starting datetime (if desired)
+        :type from_datetime: ``datetime.datetime``
         :param num_events: The number of events to return.
         :type num_events: ``int``
         :rtype: ``list``
         """
         params: Dict[str, Any] = {}
-        if from_timestamp:
-            params["fromTimestamp"] = from_timestamp
+        if from_datetime:
+            params["fromTimestamp"] = from_datetime.timestamp()
         if num_events:
             params["numEvents"] = num_events
 

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -286,7 +286,7 @@ class System:
         """
         params: Dict[str, Any] = {}
         if from_datetime:
-            params["fromTimestamp"] = from_datetime.timestamp()
+            params["fromTimestamp"] = round(from_datetime.timestamp())
         if num_events:
             params["numEvents"] = num_events
 

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,5 +1,6 @@
 """Define tests for the System object."""
 # pylint: disable=protected-access,redefined-outer-name,unused-import
+from datetime import datetime
 import json
 
 import aiohttp
@@ -66,7 +67,7 @@ async def test_get_events(events_json, v2_server):
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
 
-            events = await system.get_events(1534725051, 2)
+            events = await system.get_events(datetime.now(), 2)
 
             assert len(events) == 2
 


### PR DESCRIPTION
**Describe what the PR does:**

`system.get_events()` previously had a `from_timestamp` parameter that took an int. I think it's more likely that people will want to pass a `datetime.datetime`, so this PR makes that change.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
