### PR TITLE
Bump mypy (in pre-commit) to 0.761

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
           - toml
         files: ^(simplipy|scripts|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.750
+    rev: v0.761
     hooks:
       - id: mypy
         files: ^(simplipy|scripts)/.+\.py$


### PR DESCRIPTION
**Describe what the PR does:**

When I bumped `mypy`'s version in `pyproject.toml`, I neglected to also do it `.pre-commit-config.yaml`. This PR rectifies that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
