### PR TITLE
Remove support for Python 3.6

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,6 @@ Python Versions
 
 ``simplisafe-python`` is currently supported on:
 
-* Python 3.6
 * Python 3.7
 * Python 3.8
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -41,7 +40,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
-python = "^3.6.1"
+python = "^3.7.0"
 python-engineio = ">= 3.9.3"
 python-socketio = ">=4.3.1"
 voluptuous = "^0.11.7"


### PR DESCRIPTION
**Describe what the PR does:**

I want to begin using `dataclasses` where appropriate, which requires Python 3.7. So, this PR removes official support for Python 3.6.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
