### PR TITLE
Add support for retrieving system messages

### DIFF
--- a/docs/message.rst
+++ b/docs/message.rst
@@ -2,10 +2,10 @@ Messages
 ========
 
 At various times (most notably when dealing with
-:ref:`websocket events <websocket:Responding to Events>`), ``simplipy`` will make use of
-:meth:`simplipy.helpers.message.Message` objects. These objects provide an easy-to-use
-interface for this data, rather than dealing with raw, sometimes difficult-to-decipher
-data directly from SimpliSafe™.
+:ref:`websocket events <websocket:Responding to Events>` and system notifications),
+``simplipy`` will make use of :meth:`simplipy.helpers.message.Message` objects. These
+objects provide an easy-to-use interface for this data, rather than dealing with raw,
+sometimes difficult-to-decipher data directly from SimpliSafe™.
 
 Each object has the following properties:
 

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -147,6 +147,10 @@ additional properties:
     system.light
     # >>> True
 
+     # Return any active system messages/notifications
+    system.messages
+    # >>> [Message(...)]
+
     # Return whether the system is offline:
     system.offline
     # >>> False

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -54,6 +54,10 @@ All ``System`` objects come with a standard set of properties
     system.connection_type
     # >>> "cell"
 
+    # Return a list of active messages/notifications:
+    system.messages
+    # >>> [<simplipy.system.SystemMessage object>, ...]
+
     # Return a list of sensors attached to this system
     # (detailed later):
     system.sensors
@@ -84,6 +88,15 @@ All ``System`` objects come with a standard set of properties
     # Return the SimpliSafe™ version:
     system.version
     # >>> 2
+
+``SystemMessage`` objects have the following fields available:
+
+* ``message_id``: the ID of the message
+* ``category``: the category of the message
+* ``code``: the internal SimpliSafe message code
+* ``text``: the text of the message
+* ``link``: a link to more information about the message
+* ``timestamp``: when the message was sent
 
 V3 Properties
 -------------

--- a/simplipy/helpers/message.py
+++ b/simplipy/helpers/message.py
@@ -1,8 +1,9 @@
 """Define helpers for messages (websocket events, notifications, etc)."""
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 import logging
 from typing import Optional
+from uuid import uuid4
 
 from simplipy.entity import EntityTypes
 from simplipy.util.dt import utc_from_timestamp
@@ -20,6 +21,7 @@ class Message:
     timestamp: datetime
 
     changed_by: Optional[str] = None
+    message_id: str = field(default_factory=lambda: uuid4().hex)
     sensor_name: Optional[str] = None
     sensor_serial: Optional[str] = None
     sensor_type: Optional[EntityTypes] = None

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -192,9 +192,7 @@ class System:
         messages: List[Message] = []
         for raw_message in self._location_info["system"]["messages"]:
             category = raw_message["category"].title()
-            text = (
-                f'SimpliSafe {category} #{raw_message["code"]}: {raw_message["text"]}'
-            )
+            text = f'SimpliSafe {category} Code {raw_message["code"]}: {raw_message["text"]}'
             if raw_message.get("link"):
                 text += f' More information: {raw_message["link"]}'
 

--- a/tests/fixtures/v3_subscriptions_response.json
+++ b/tests/fixtures/v3_subscriptions_response.json
@@ -53,7 +53,24 @@
                     "cameras": [],
                     "connType": "wifi",
                     "stateUpdated": 1573331519,
-                    "messages": [],
+                    "messages": [
+                        {
+                            "_id": "xxxxxxxxxxxxxxxxxxxxxxxx",
+                            "id": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+                            "textTemplate": "Power Outage - Backup battery in use.",
+                            "data": {
+                                "time": "2020-02-16T03:20:28+00:00"
+                            },
+                            "text": "Power Outage - Backup battery in use.",
+                            "code": "2000",
+                            "filters": [],
+                            "link": "",
+                            "linkLabel": "",
+                            "expiration": 0,
+                            "category": "error",
+                            "timestamp": 1581823228
+                        }
+                    ],
                     "powerOutage": false,
                     "lastPowerOutage": 1570722271,
                     "lastSuccessfulWifiTS": 1573246093,

--- a/tests/fixtures/v3_subscriptions_response.json
+++ b/tests/fixtures/v3_subscriptions_response.json
@@ -64,7 +64,7 @@
                             "text": "Power Outage - Backup battery in use.",
                             "code": "2000",
                             "filters": [],
-                            "link": "",
+                            "link": "http://link.to.info",
                             "linkLabel": "",
                             "expiration": 0,
                             "category": "error",

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -858,7 +858,7 @@ async def test_system_messages(aresponses, v3_server):
             message1 = system.messages[0]
             assert message1.message_id == "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
             assert message1.message == (
-                "SimpliSafe Error #2000: Power Outage - Backup battery in use. "
+                "SimpliSafe Error Code 2000: Power Outage - Backup battery in use. "
                 "More information: http://link.to.info"
             )
             assert message1.system_id == system.system_id

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -927,6 +927,11 @@ async def test_update_system_data_v3(aresponses, v3_server):
 
             await system.update()
 
+            assert len(system.messages) == 1
+
+            message = system.messages[0]
+            assert message.code == "2000"
+
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
             assert simplisafe._access_token == TEST_ACCESS_TOKEN


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds support for retrieving system messages and returning them as `Message` objects.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/90
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
