### PR TITLE
Convert websocket events to a dataclass

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,6 +50,13 @@ API Reference
 .. autoclass:: simplipy.errors.InvalidCredentialsError
    :members:
 
+``Message``
+------------------
+
+.. autoclass:: simplipy.helpers.message.Message
+   :members:
+   :undoc-members:
+
 ``PinError``
 ------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ master_doc = "index"
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ["sphinx.ext.autodoc"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.autosectionlabel"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
@@ -71,3 +71,4 @@ html_static_path = ["_static"]
 # -- Options for autodoc -------------------------------------------------
 
 autodoc_default_options = {"member-order": "bysource"}
+autosectionlabel_prefix_document = True

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ and more.
    sensor
    lock
    websocket
+   message
    advanced
    api
 

--- a/docs/message.rst
+++ b/docs/message.rst
@@ -1,0 +1,19 @@
+Messages
+========
+
+At various times (most notably when dealing with
+:ref:`websocket events <websocket:Responding to Events>`), ``simplipy`` will make use of
+:meth:`simplipy.helpers.message.Message` objects. These objects provide an easy-to-use
+interface for this data, rather than dealing with raw, sometimes difficult-to-decipher
+data directly from SimpliSafe™.
+
+Each object has the following properties:
+
+* ``changed_by``: In cases of messages about system arm/disarm events, the PIN that caused the message
+* ``event``: The event that caused the message (e.g., ``lock_unlocked``)
+* ``message``: The message text
+* ``sensor_name``: The sensor name that caused the message (if appropriate)
+* ``sensor_serial``: The sensor serial number that caused the message (if appropriate)
+* ``sensor_type``: The sensor type that caused the message (if appropriate)
+* ``system_id``: The system ID for which the message applies
+* ``timestamp``: The UTC ``datetime`` that the message was generated

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -49,8 +49,8 @@ or a coroutine).
 ``connect``
 ***********
 
-Asynchronous
-============
+Asynchronous Connect Callback
+=============================
 
 .. code:: python
 
@@ -59,8 +59,8 @@ Asynchronous
 
     simplisafe.websocket.async_on_connect(async_connect_handler)
 
-Synchronous
-===========
+Synchronous Connect Callback
+============================
 
 .. code:: python
 
@@ -72,8 +72,8 @@ Synchronous
 ``disconnect``
 **************
 
-Asynchronous
-============
+Asynchronous Disconnect Callback
+================================
 
 .. code:: python
 
@@ -82,8 +82,8 @@ Asynchronous
 
     simplisafe.websocket.async_on_disconnect(async_disconnect_handler)
 
-Synchronous
-===========
+Synchronous Disconnect Callback
+===============================
 
 .. code:: python
 
@@ -93,72 +93,41 @@ Synchronous
     simplisafe.websocket.on_disconnect(disconnect_handler)
 
 ``event``
-**************
+*********
 
-Asynchronous
-============
+Asynchronous Event Callback
+===========================
 
 .. code:: python
 
-    async def async_event_handler(data):
-        print(f"I also got some data: {data}")
+    async def async_event_handler(message):
+        print(f"SimpliSafe websocket message: {message}")
 
     simplisafe.websocket.async_on_event(async_event_handler)
 
-Synchronous
-===========
+Synchronous Event Callback
+==========================
 
 .. code:: python
 
-    def event_handler(data):
-        print(f"I got some data: {data}")
+    def event_handler(message):
+        print(f"SimpliSafe websocket message: {message}")
 
     simplisafe.websocket.on_event(event_handler)
 
 Response Format
 ===============
 
-The ``data`` argument has the same schema as data returned from ``system.get_events()``.
-For example, when the system is armed in home mode, users may expect a ``data`` argument
-with this value:
+The ``message`` argument will be a :ref:`message object <message:Messages>`:
 
-.. code:: json
-
-    {
-      "eventId": 1231231231,
-      "eventTimestamp": 1231231231,
-      "eventCid": 1231,
-      "zoneCid": "3",
-      "sensorType": 0,
-      "sensorSerial": "",
-      "account": "xxxxxxxx",
-      "userId": 123123,
-      "sid": 123123,
-      "info": "System Armed (Home) by Remote Management",
-      "pinName": "",
-      "sensorName": "",
-      "messageSubject": "SimpliSafe System Armed (home mode)",
-      "messageBody": "System Armed (home mode)",
-      "eventType": "activity",
-      "timezone": 2,
-      "locationOffset": -420,
-      "videoStartedBy": "",
-      "video": {}
-    }
-
-``simplisafe-python`` provides a helper to determine the type of websocket event
-represented by the ``data`` argument:
 
 .. code:: python
 
-    from simplipy.websocket import get_event_type_from_payload
+    print(message)
+    # >>> Message(event='alarm_canceled', message="The system was disarmed" ...)
 
-    def event_handler(data):
-        print(f"Event type: {get_event_type_from_payload(data)}")
 
-    simplisafe.websocket.on_event(event_handler)
-
-This helper will currently return one of the following values:
+...and the ``event`` property of that object will be one of the following:
 
 * ``alarm_canceled``
 * ``alarm_triggered``

--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -9,8 +9,8 @@ from simplipy.errors import SimplipyError, WebsocketError
 
 _LOGGER = logging.getLogger()
 
-SIMPLISAFE_EMAIL = "<EMAIL>"  # nosec
-SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
+SIMPLISAFE_EMAIL = "bachya1208@gmail.com"  # nosec
+SIMPLISAFE_PASSWORD = "gcapt3c4uUTBjN*LpGo*gm3A!7Y8HP"  # nosec
 
 
 def print_data(data):
@@ -51,6 +51,12 @@ async def main() -> None:
 
         except SimplipyError as err:
             _LOGGER.error(err)
+
+        for _ in range(30):
+            _LOGGER.info("Simulating some other task occurring...")
+            await asyncio.sleep(5)
+
+        await simplisafe.websocket.disconnect()
 
 
 asyncio.get_event_loop().run_until_complete(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ aiohttp = "^3.6.2"
 python = "^3.7.0"
 python-engineio = ">= 3.9.3"
 python-socketio = ">=4.3.1"
+pytz = "^2019.3"
 voluptuous = "^0.11.7"
 websockets = "^8.1"
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -5,4 +5,5 @@ pytest-cov==2.8.1
 pytest==5.3.5
 python-engineio==3.11.1
 python-socketio==4.4.0
+pytz==2019.3
 voluptuous==0.11.7

--- a/simplipy/helpers/__init__.py
+++ b/simplipy/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Define package helpers."""

--- a/simplipy/helpers/message.py
+++ b/simplipy/helpers/message.py
@@ -1,0 +1,41 @@
+"""Define helpers for messages (websocket events, notifications, etc)."""
+from dataclasses import dataclass
+from datetime import datetime
+import logging
+from typing import Optional
+
+from simplipy.entity import EntityTypes
+from simplipy.util.dt import utc_from_timestamp
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)  # pylint: disable=too-many-instance-attributes
+class Message:
+    """Define a representation of a message."""
+
+    event: Optional[str]
+    message: str
+    system_id: int
+    timestamp: datetime
+
+    changed_by: Optional[str] = None
+    sensor_name: Optional[str] = None
+    sensor_serial: Optional[str] = None
+    sensor_type: Optional[EntityTypes] = None
+
+    def __post_init__(self):
+        """Run post-init initialization."""
+        object.__setattr__(self, "timestamp", utc_from_timestamp(self.timestamp))
+
+        if self.sensor_type is not None:
+            try:
+                object.__setattr__(self, "sensor_type", EntityTypes(self.sensor_type))
+            except ValueError:
+                _LOGGER.warning(
+                    'Encountered unknown entity type: %s ("%s"). Please report it at'
+                    "https://github.com/home-assistant/home-assistant/issues.",
+                    self.sensor_type,
+                    self.message,
+                )
+                object.__setattr__(self, "sensor_type", None)

--- a/simplipy/util/dt.py
+++ b/simplipy/util/dt.py
@@ -1,0 +1,11 @@
+"""Define datetime utilities."""
+from datetime import datetime
+
+import pytz
+
+UTC = pytz.utc
+
+
+def utc_from_timestamp(timestamp: float) -> datetime:
+    """Return a UTC time from a timestamp."""
+    return UTC.localize(datetime.utcfromtimestamp(timestamp))

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Test helpers."""

--- a/tests/helpers/test_message.py
+++ b/tests/helpers/test_message.py
@@ -1,0 +1,54 @@
+"""Test message helpers."""
+from datetime import datetime
+
+import pytz
+
+from simplipy.entity import EntityTypes
+from simplipy.helpers.message import Message
+
+
+def test_create_message():
+    """Test the successful creation of a message."""
+    basic_message = Message("event", "This is a test message", 1234, 1581892842)
+    assert basic_message.event == "event"
+    assert basic_message.message == "This is a test message"
+    assert basic_message.system_id == 1234
+    assert basic_message.timestamp == datetime(2020, 2, 16, 22, 40, 42, tzinfo=pytz.UTC)
+    assert not basic_message.changed_by
+    assert not basic_message.sensor_name
+    assert not basic_message.sensor_serial
+    assert not basic_message.sensor_type
+
+    complete_message = Message(
+        "event",
+        "This is a test message",
+        1234,
+        1581892842,
+        changed_by="1234",
+        sensor_name="Kitchen Window",
+        sensor_serial="ABC123",
+        sensor_type=5,
+    )
+    assert complete_message.event == "event"
+    assert complete_message.message == "This is a test message"
+    assert complete_message.system_id == 1234
+    assert complete_message.timestamp == datetime(
+        2020, 2, 16, 22, 40, 42, tzinfo=pytz.UTC
+    )
+    assert complete_message.changed_by == "1234"
+    assert complete_message.sensor_name == "Kitchen Window"
+    assert complete_message.sensor_serial == "ABC123"
+    assert complete_message.sensor_type == EntityTypes.entry
+
+    assert basic_message != complete_message
+
+
+def test_unknown_sensor_type(caplog):
+    """Test creating a message with an unknown sensor type."""
+    message = Message(
+        "event", "This is a test message", 1234, 1581892842, sensor_type="doesnt_exist"
+    )
+
+    assert any("Encountered unknown entity type" in e.message for e in caplog.records)
+    assert any("doesnt_exist" in e.message for e in caplog.records)
+    assert not message.sensor_type

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -49,7 +49,7 @@ async def test_connect_async_success(v3_server):
                 transports=["websocket"],
             )
 
-            await simplisafe.websocket._sio._trigger_event("connect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("connect", "/")
             on_connect.mock.assert_called_once()
 
 
@@ -80,7 +80,7 @@ async def test_connect_sync_success(v3_server):
                 transports=["websocket"],
             )
 
-            await simplisafe.websocket._sio._trigger_event("connect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("connect", "/")
             on_connect.assert_called_once()
 
 
@@ -133,16 +133,38 @@ async def test_async_events(v3_server):
                 transports=["websocket"],
             )
 
-            await simplisafe.websocket._sio._trigger_event("connect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("connect", "/")
             on_connect.mock.assert_called_once()
 
             await simplisafe.websocket._sio._trigger_event(
-                "event", namespace=f"/v1/user/{TEST_USER_ID}"
+                "event",
+                f"/v1/user/{TEST_USER_ID}",
+                {
+                    "eventId": 1231231231,
+                    "eventTimestamp": 1231231231,
+                    "eventCid": 1231,
+                    "zoneCid": "3",
+                    "sensorType": 0,
+                    "sensorSerial": "",
+                    "account": "xxxxxxxx",
+                    "userId": 123123,
+                    "sid": 123123,
+                    "info": "System Armed (Home) by Remote Management",
+                    "pinName": "",
+                    "sensorName": "",
+                    "messageSubject": "SimpliSafe System Armed (home mode)",
+                    "messageBody": "System Armed (home mode)",
+                    "eventType": "activity",
+                    "timezone": 2,
+                    "locationOffset": -420,
+                    "videoStartedBy": "",
+                    "video": {},
+                },
             )
             on_event.mock.assert_called_once()
 
             await simplisafe.websocket.async_disconnect()
-            await simplisafe.websocket._sio._trigger_event("disconnect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("disconnect", "/")
             simplisafe.websocket._sio.eio.disconnect.mock.assert_called_once_with(
                 abort=True
             )
@@ -195,16 +217,38 @@ async def test_sync_events(v3_server):
                 transports=["websocket"],
             )
 
-            await simplisafe.websocket._sio._trigger_event("connect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("connect", "/")
             on_connect.assert_called_once()
 
             await simplisafe.websocket._sio._trigger_event(
-                "event", namespace=f"/v1/user/{TEST_USER_ID}"
+                "event",
+                f"/v1/user/{TEST_USER_ID}",
+                {
+                    "eventId": 1231231231,
+                    "eventTimestamp": 1231231231,
+                    "eventCid": 1231,
+                    "zoneCid": "3",
+                    "sensorType": 0,
+                    "sensorSerial": "",
+                    "account": "xxxxxxxx",
+                    "userId": 123123,
+                    "sid": 123123,
+                    "info": "System Armed (Home) by Remote Management",
+                    "pinName": "",
+                    "sensorName": "",
+                    "messageSubject": "SimpliSafe System Armed (home mode)",
+                    "messageBody": "System Armed (home mode)",
+                    "eventType": "activity",
+                    "timezone": 2,
+                    "locationOffset": -420,
+                    "videoStartedBy": "",
+                    "video": {},
+                },
             )
             on_event.assert_called_once()
 
             await simplisafe.websocket.async_disconnect()
-            await simplisafe.websocket._sio._trigger_event("disconnect", namespace="/")
+            await simplisafe.websocket._sio._trigger_event("disconnect", "/")
             simplisafe.websocket._sio.eio.disconnect.mock.assert_called_once_with(
                 abort=True
             )


### PR DESCRIPTION
**Describe what the PR does:**

Previously, the websocket's `async_on_event` and `on_event` callbacks gave the user raw data from the websocket. This put burden on the caller to know what to do with those results; with system notifications looking to use the same mechanism, this creates too much "loose" data. So, this PR alters `async_on_event` and `on_event` to return a `Message` dataclass.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
