### PR TITLE
Add "maintenance" label to release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,6 +11,7 @@ categories:
       - "ci/cd"
       - "dependencies"
       - "docs"
+      - "maintenance"
       - "tooling"
 change-template: "- $TITLE (#$NUMBER)"
 name-template: "$NEXT_PATCH_VERSION"


### PR DESCRIPTION
**Describe what the PR does:**

This PR ensures that the release drafter GitHub action will categorize PRs with the `maintenance` label under the appropriate  heading.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
