### PR TITLE
Streamline websocket reconnections with new tokens

### DIFF
--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -9,8 +9,8 @@ from simplipy.errors import SimplipyError, WebsocketError
 
 _LOGGER = logging.getLogger()
 
-SIMPLISAFE_EMAIL = "bachya1208@gmail.com"  # nosec
-SIMPLISAFE_PASSWORD = "gcapt3c4uUTBjN*LpGo*gm3A!7Y8HP"  # nosec
+SIMPLISAFE_EMAIL = "<EMAIL>"  # nosec
+SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 
 def print_data(data):

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -48,7 +48,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.email: Optional[str] = None
         self.refresh_token_dirty: bool = False
         self.user_id: Optional[int] = None
-        self.websocket: Websocket = None  # type: ignore
+        self.websocket: Websocket = Websocket()
 
     @property
     def refresh_token(self) -> str:
@@ -135,10 +135,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         auth_check_resp: dict = await self._request("get", "api/authCheck")
         self.user_id = auth_check_resp["userId"]
 
-        if self.websocket:
-            self.websocket.access_token = self._access_token
-        else:
-            self.websocket = Websocket(self._access_token, self.user_id)  # type: ignore
+        await self.websocket.async_init(self._access_token, self.user_id)
 
     async def _get_subscription_data(self) -> dict:
         """Get the latest location-level data."""


### PR DESCRIPTION
**Describe what the PR does:**

This PR updates the websocket to handle reconnection logic in the case of an updated access token. If the websocket is connected when the token updates, it will disconnect and reconnect.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
