### PR TITLE
Remove refresh_token_dirty property from API object

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -17,7 +17,7 @@ usage of these properties is solely your responsibility.**
 .. code:: python
 
     # Return the current access token:
-    simplisafe._access_token
+    simplisafe.access_token
     # >>> 7s9yasdh9aeu21211add
 
     # Return the current refresh token:

--- a/examples/test_sensor_properties.py
+++ b/examples/test_sensor_properties.py
@@ -27,10 +27,7 @@ async def main() -> None:
                 _LOGGER.info("System ID: %s", system_id)
                 _LOGGER.info("Version: %s", system.version)
                 _LOGGER.info("User ID: %s", simplisafe.user_id)
-                _LOGGER.info(
-                    "Access Token: %s",
-                    simplisafe._access_token,  # pylint: disable=protected-access
-                )
+                _LOGGER.info("Access Token: %s", simplisafe.access_token)
                 _LOGGER.info("Refresh Token: %s", simplisafe.refresh_token)
 
                 events = await system.get_events()

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -46,9 +46,16 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._uuid: UUID = uuid4()
         self._websession: ClientSession = websession
         self.email: Optional[str] = None
-        self.refresh_token_dirty: bool = False
         self.user_id: Optional[int] = None
         self.websocket: Websocket = Websocket()
+
+    @property
+    def access_token(self) -> str:
+        """Return the current access token.
+
+        :rtype: ``str``
+        """
+        return self._access_token
 
     @property
     def refresh_token(self) -> str:
@@ -56,23 +63,7 @@ class API:  # pylint: disable=too-many-instance-attributes
 
         :rtype: ``str``
         """
-        if self.refresh_token_dirty:
-            self.refresh_token_dirty = False
-
         return self._refresh_token
-
-    @refresh_token.setter
-    def refresh_token(self, value: str) -> None:
-        """Set the refresh token if it has changed.
-
-        :param value: The new refresh token
-        :type value: ``str``
-        """
-        if value == self._refresh_token:
-            return
-
-        self._refresh_token = value
-        self.refresh_token_dirty = True
 
     @classmethod
     async def login_via_credentials(
@@ -130,7 +121,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self._access_token_expire = datetime.now() + timedelta(
             seconds=int(token_resp["expires_in"]) - 60
         )
-        self.refresh_token = token_resp["refresh_token"]
+        self._refresh_token = token_resp["refresh_token"]
 
         auth_check_resp: dict = await self._request("get", "api/authCheck")
         self.user_id = auth_check_resp["userId"]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -122,10 +122,7 @@ async def test_401_refresh_token_success(aresponses, v2_server):
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
             await system.update()
-
-            assert simplisafe.refresh_token_dirty
             assert simplisafe.refresh_token == TEST_REFRESH_TOKEN
-            assert not simplisafe.refresh_token_dirty
 
 
 @pytest.mark.asyncio
@@ -237,10 +234,7 @@ async def test_refresh_token_dirtiness(aresponses, v2_server):
             )
             simplisafe._access_token_expire = datetime.now() - timedelta(hours=1)
             await simplisafe._request("get", "api/authCheck")
-
-            assert simplisafe.refresh_token_dirty
             assert simplisafe.refresh_token == TEST_REFRESH_TOKEN
-            assert not simplisafe.refresh_token_dirty
 
 
 @pytest.mark.asyncio

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -8,7 +8,7 @@ import pytz
 
 from simplipy import API
 from simplipy.errors import InvalidCredentialsError, PinError, SimplipyError
-from simplipy.system import System, SystemStates
+from simplipy.system import SystemStates
 from simplipy.system.v3 import VOLUME_HIGH, VOLUME_MEDIUM
 
 from .common import (
@@ -21,7 +21,6 @@ from .common import (
     TEST_SYSTEM_ID,
     TEST_SYSTEM_SERIAL_NO,
     TEST_USER_ID,
-    async_mock,
     load_fixture,
 )
 
@@ -177,7 +176,7 @@ async def test_get_systems_v2(aresponses, v2_server):
             system = systems[TEST_SYSTEM_ID]
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35
 
             simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
@@ -187,7 +186,7 @@ async def test_get_systems_v2(aresponses, v2_server):
             system = systems[TEST_SYSTEM_ID]
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35
 
 
@@ -250,7 +249,7 @@ async def test_get_systems_v3(aresponses, v3_server):
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 22
 
             simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
@@ -261,7 +260,7 @@ async def test_get_systems_v3(aresponses, v3_server):
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 22
 
 
@@ -937,7 +936,7 @@ async def test_update_system_data_v2(aresponses, v2_server):
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35
 
 
@@ -981,7 +980,7 @@ async def test_update_system_data_v3(aresponses, v3_server):
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe._access_token == TEST_ACCESS_TOKEN
+            assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 22
 
 


### PR DESCRIPTION
**Describe what the PR does:**

The `refresh_token_dirty` property of the `API` object was too "automagical." This PR removes the concept entirely in favor of merely making the refresh token accessible through a property and relying on implementing libraries to do their own checks as to whether a refresh token is different from the one they have.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
