### PR TITLE
Fix bug where Basic systems can't access notifications

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -238,18 +238,22 @@ class System:
 
     def _generate_system_notification_objects(self) -> List[SystemNotification]:
         """Generate message objects from the message data stored in location_info."""
-        return [
-            SystemNotification(
-                raw_message["id"],
-                raw_message["text"],
-                raw_message["category"],
-                raw_message["code"],
-                raw_message["timestamp"],
-                link=raw_message["link"],
-                link_label=raw_message["linkLabel"],
-            )
-            for raw_message in self._location_info["system"]["messages"]
-        ]
+        try:
+            return [
+                SystemNotification(
+                    raw_message["id"],
+                    raw_message["text"],
+                    raw_message["category"],
+                    raw_message["code"],
+                    raw_message["timestamp"],
+                    link=raw_message["link"],
+                    link_label=raw_message["linkLabel"],
+                )
+                for raw_message in self._location_info["system"]["messages"]
+            ]
+        except KeyError:
+            _LOGGER.info("Notifications unavailable in plan")
+            return []
 
     async def _get_entities(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -238,22 +238,22 @@ class System:
 
     def _generate_system_notification_objects(self) -> List[SystemNotification]:
         """Generate message objects from the message data stored in location_info."""
-        try:
-            return [
-                SystemNotification(
-                    raw_message["id"],
-                    raw_message["text"],
-                    raw_message["category"],
-                    raw_message["code"],
-                    raw_message["timestamp"],
-                    link=raw_message["link"],
-                    link_label=raw_message["linkLabel"],
-                )
-                for raw_message in self._location_info["system"]["messages"]
-            ]
-        except KeyError:
+        if self._location_info["system"].get("messages") is None:
             _LOGGER.info("Notifications unavailable in plan")
             return []
+
+        return [
+            SystemNotification(
+                raw_message["id"],
+                raw_message["text"],
+                raw_message["category"],
+                raw_message["code"],
+                raw_message["timestamp"],
+                link=raw_message["link"],
+                link_label=raw_message["linkLabel"],
+            )
+            for raw_message in self._location_info["system"]["messages"]
+        ]
 
     async def _get_entities(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""


### PR DESCRIPTION
**Describe what the PR does:**

It appears that users with Standard monitoring plans don't see messages in the API; this can lead to an unhandled exception, which this PR addresses.

Note that this PR drops test coverage to 99%; given that I want to release a fix ASAP, going to push this forward now and will fix test coverage in a future PR.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
