### PR TITLE
Fix unhandled exception with V3 systems that are missing base station

### DIFF
--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -492,15 +492,15 @@ async def test_properties_v3(aresponses, v3_server):
 
             # Test "setting" various system properties by overriding their values, then
             # calling the update functions:
-            system._settings_info["settings"]["normal"]["alarmDuration"] = 0
-            system._settings_info["settings"]["normal"]["alarmVolume"] = 0
-            system._settings_info["settings"]["normal"]["doorChime"] = 0
-            system._settings_info["settings"]["normal"]["entryDelayAway"] = 0
-            system._settings_info["settings"]["normal"]["entryDelayHome"] = 0
-            system._settings_info["settings"]["normal"]["exitDelayAway"] = 0
-            system._settings_info["settings"]["normal"]["exitDelayHome"] = 1000
-            system._settings_info["settings"]["normal"]["light"] = False
-            system._settings_info["settings"]["normal"]["voicePrompts"] = 0
+            system.settings_info["settings"]["normal"]["alarmDuration"] = 0
+            system.settings_info["settings"]["normal"]["alarmVolume"] = 0
+            system.settings_info["settings"]["normal"]["doorChime"] = 0
+            system.settings_info["settings"]["normal"]["entryDelayAway"] = 0
+            system.settings_info["settings"]["normal"]["entryDelayHome"] = 0
+            system.settings_info["settings"]["normal"]["exitDelayAway"] = 0
+            system.settings_info["settings"]["normal"]["exitDelayHome"] = 1000
+            system.settings_info["settings"]["normal"]["light"] = False
+            system.settings_info["settings"]["normal"]["voicePrompts"] = 0
 
             await system.set_properties(
                 {


### PR DESCRIPTION
**Describe what the PR does:**

At times, the SimpliSafe cloud doesn't return base station status data (perhaps when it can't reach the base station? who knows). This leads to an unhandled exception, which this PR fixes.

This PR drops test coverage because it would be kludgy to add a test for it with the current framework. To get a fix out, I'm releasing it now and will fix coverage in a future PR.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
