### PR TITLE
Fix bug where empty and/or missing events weren't handled correctly

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -348,7 +348,7 @@ class System:
 
         _LOGGER.debug("Events response: %s", events_resp)
 
-        return events_resp["events"]
+        return events_resp.get("events", [])
 
     async def get_latest_event(self) -> dict:
         """Get the most recent system event.
@@ -356,7 +356,11 @@ class System:
         :rtype: ``dict``
         """
         events: list = await self.get_events(num_events=1)
-        return events[0]
+
+        try:
+            return events[0]
+        except IndexError:
+            raise SimplipyError("SimpliSafe cloud didn't return any events")
 
     async def get_pins(self, cached: bool = True) -> Dict[str, str]:
         """Return all of the set PINs, including master and duress.

--- a/tests/fixtures/events_empty_response.json
+++ b/tests/fixtures/events_empty_response.json
@@ -1,0 +1,5 @@
+{
+    "numEvents": 0,
+    "lastEventTimestamp": 1534035861,
+    "events": []
+}

--- a/tests/fixtures/events_missing_response.json
+++ b/tests/fixtures/events_missing_response.json
@@ -1,0 +1,4 @@
+{
+    "numEvents": 0,
+    "lastEventTimestamp": 1534035861
+}


### PR DESCRIPTION
**Describe what the PR does:**

It appears that the SimpliSafe cloud can sometimes fail to return event JSON (perhaps via an empty list _or_ via the `events` key missing altogether). This PR implements proper exception handling in such a case.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
