### PR TITLE
Fix unknown state on triggered alarm

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -110,15 +110,16 @@ class SystemNotification:
 class SystemStates(Enum):
     """States that the system can be in."""
 
-    alarm_count = 1
-    away = 2
-    away_count = 3
-    entry_delay = 4
-    error = 5
-    exit_delay = 6
-    home = 7
-    home_count = 8
-    off = 9
+    alarm = 1
+    alarm_count = 2
+    away = 3
+    away_count = 4
+    entry_delay = 5
+    error = 6
+    exit_delay = 7
+    home = 8
+    home_count = 9
+    off = 10
     unknown = 99
 
 


### PR DESCRIPTION
**Describe what the PR does:**

A triggered alarm was causing the system to report its state as `unknown` – this is because I had never actually tested a triggered alarm, so I had no definition for its state. 😆 This PR fixes that.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/145
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
