### PR TITLE
Make aiohttp ClientSession optional

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -39,7 +39,7 @@ when it comes time to re-authenticate, simply:
 .. code:: python
 
     simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", websession
+        "<REFRESH TOKEN>", session=session
     )
 
 During usage, ``simplipy`` will automatically refresh the access token as needed.
@@ -48,7 +48,7 @@ At any point, the "dirtiness" of the token can be checked:
 .. code:: python
 
     simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", websession
+        "<REFRESH TOKEN>", session=session
     )
 
     # Assuming the access token was automatically refreshed:

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -25,9 +25,9 @@ To get all SimpliSafe™ systems associated with an account:
 
     async def main() -> None:
         """Create the aiohttp session and run."""
-        async with ClientSession() as websession:
+        async with ClientSession() as session:
             simplisafe = await simplipy.API.login_via_credentials(
-                "<EMAIL>", "<PASSWORD>", websession
+                "<EMAIL>", "<PASSWORD>", session=session
             )
 
             # Get a dict of systems with the system ID as the key:
@@ -35,7 +35,7 @@ To get all SimpliSafe™ systems associated with an account:
             # >>> {"1234abc": <simplipy.system.SystemV2 object>, ...}
 
 
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 
 Core Properties
 ---------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,12 +36,14 @@ Please note that only Interactive plans can access sensor values and set the
 system state; using the API with a Standard plan will be limited to retrieving
 the current system state.
 
-Scaffolding
------------
+Connection Pooling
+------------------
 
-Installing ``simplipy`` also includes ``aiohttp``, which is the engine that powers
-the entire library. All interactions with ``simplipy`` start within an
-``aiohttp`` ``ClientSession``:
+By default, the :meth:`API <simplipy.api.API>` object creates a new connection to
+SimpliSafe™ with each coroutine. If you are calling a large number of coroutines (or
+merely want to squeeze out every second of runtime savings possible), an
+``aiohttp ClientSession`` can be supplied when logging into the API (via credentials or
+token) to achieve connection pooling:
 
 .. code:: python
 
@@ -53,10 +55,14 @@ the entire library. All interactions with ``simplipy`` start within an
 
     async def main() -> None:
         """Create the aiohttp session and run."""
-        async with ClientSession() as websession:
-            # YOUR CODE HERE
+        async with ClientSession() as session:
+            simplisafe = await API.login_via_credentials(
+                "<EMAIL>", "<PASSWORD>", session=session
+            )
+
+            # ...
 
 
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())
 
-Every example within this documentation assumes the use of the above scaffolding.
+Every example in this documentation uses this pattern.

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -8,7 +8,7 @@ events from a user's SimpliSafe™ system. This websocket can be accessed via th
 .. code:: python
 
     simplisafe = await simplipy.API.login_via_credentials(
-        "<EMAIL>", "<PASSWORD>", websession
+        "<EMAIL>", "<PASSWORD>", session=session
     )
 
     simplisafe.websocket

--- a/examples/test_events.py
+++ b/examples/test_events.py
@@ -15,12 +15,12 @@ SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             for system in systems.values():
@@ -31,4 +31,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/examples/test_locks.py
+++ b/examples/test_locks.py
@@ -16,12 +16,12 @@ SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             for system in systems.values():
@@ -45,4 +45,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/examples/test_sensor_properties.py
+++ b/examples/test_sensor_properties.py
@@ -15,12 +15,12 @@ SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             for system_id, system in systems.items():
@@ -45,4 +45,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/examples/test_sensor_types.py
+++ b/examples/test_sensor_types.py
@@ -15,12 +15,12 @@ SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             for system in systems.values():
@@ -36,4 +36,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/examples/test_system_state.py
+++ b/examples/test_system_state.py
@@ -15,12 +15,12 @@ SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             for system in systems.values():
@@ -31,4 +31,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -30,12 +30,12 @@ def print_hello():
 
 async def main() -> None:
     """Create the aiohttp session and run the example."""
-    async with ClientSession() as websession:
+    async with ClientSession() as session:
         logging.basicConfig(level=logging.INFO)
 
         try:
             simplisafe = await API.login_via_credentials(
-                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, websession
+                SIMPLISAFE_EMAIL, SIMPLISAFE_PASSWORD, session=session
             )
 
             simplisafe.websocket.on_connect(print_hello)
@@ -57,4 +57,4 @@ async def main() -> None:
             _LOGGER.error(err)
 
 
-asyncio.get_event_loop().run_until_complete(main())
+asyncio.run(main())

--- a/tests/sensor/__init__.py
+++ b/tests/sensor/__init__.py
@@ -12,9 +12,9 @@ from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/sensor/test_base.py
+++ b/tests/sensor/test_base.py
@@ -12,9 +12,9 @@ from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/sensor/test_v2.py
+++ b/tests/sensor/test_v2.py
@@ -12,9 +12,9 @@ from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/sensor/test_v3.py
+++ b/tests/sensor/test_v3.py
@@ -13,9 +13,9 @@ from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
 async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -30,9 +30,9 @@ async def test_properties_base(v2_server):
 async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -61,9 +61,9 @@ async def test_properties_v2(v2_server):
 async def test_properties_v3(v3_server):
     """Test that v3 sensor properties are created properly."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -92,9 +92,9 @@ async def test_properties_v3(v3_server):
 async def test_unknown_sensor_type(caplog, v2_server):
     """Test that a message is logged when unknown sensors types are found."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             _ = await simplisafe.get_systems()
             assert any("Unknown" in e.message for e in caplog.records)

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -28,9 +28,9 @@ async def test_get_events(aresponses, v2_server):
             aresponses.Response(text=load_fixture("events_response.json"), status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -41,12 +41,32 @@ async def test_get_events(aresponses, v2_server):
 
 
 @pytest.mark.asyncio
+async def test_get_events_no_explicit_session(aresponses, v2_server):
+    """Test getting events from a system without an explicit aiohttp ClientSession."""
+    async with v2_server:
+        v2_server.add(
+            "api.simplisafe.com",
+            f"/v1/subscriptions/{TEST_SYSTEM_ID}/events",
+            "get",
+            aresponses.Response(text=load_fixture("events_response.json"), status=200),
+        )
+
+        simplisafe = await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD)
+        systems = await simplisafe.get_systems()
+        system = systems[TEST_SYSTEM_ID]
+
+        events = await system.get_events(datetime.now(), 2)
+
+        assert len(events) == 2
+
+
+@pytest.mark.asyncio
 async def test_properties(v2_server):
     """Test that base system properties are created properly."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -65,9 +85,9 @@ async def test_properties(v2_server):
 async def test_unknown_sensor_type(caplog, v2_server):
     """Test whether a message is logged upon finding an unknown sensor type."""
     async with v2_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             _ = await simplisafe.get_systems()
             assert any("Unknown" in e.message for e in caplog.records)

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -29,9 +29,9 @@ async def test_get_pins(aresponses, v2_server):
             aresponses.Response(text=load_fixture("v2_pins_response.json"), status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -82,9 +82,9 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             assert len(systems) == 1
@@ -95,7 +95,7 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
             assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35
 
-            simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
+            simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, session=session)
             systems = await simplisafe.get_systems()
             assert len(systems) == 1
 
@@ -137,9 +137,9 @@ async def test_set_pin(aresponses, v2_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -192,9 +192,9 @@ async def test_set_states(aresponses, v2_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -231,9 +231,9 @@ async def test_update_system_data(aresponses, v2_server, v2_subscriptions_respon
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -31,9 +31,9 @@ from tests.common import (
 async def test_alarm_state(v3_server):
     """Test handling of a triggered alarm."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -51,9 +51,9 @@ async def test_clear_notifications(aresponses, v3_server):
             aresponses.Response(text=None, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -75,9 +75,9 @@ async def test_get_last_event(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -97,9 +97,9 @@ async def test_get_pins(aresponses, v3_server, v3_settings_response):
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -158,9 +158,9 @@ async def test_get_systems(
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             assert len(systems) == 1
@@ -172,7 +172,7 @@ async def test_get_systems(
             assert simplisafe.access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 22
 
-            simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, websession)
+            simplisafe = await API.login_via_token(TEST_REFRESH_TOKEN, session=session)
             systems = await simplisafe.get_systems()
             assert len(systems) == 1
 
@@ -197,9 +197,9 @@ async def test_empty_events(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -222,9 +222,9 @@ async def test_missing_events(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -245,9 +245,9 @@ async def test_no_notifications_in_basic_plan(caplog, v3_server):
     caplog.set_level(logging.INFO)
 
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -275,9 +275,9 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
             aresponses.Response(text="", status=401),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -296,9 +296,9 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
 async def test_missing_base_station_data(caplog, v3_server):
     """Test that missing base station data is handled correctly."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -320,9 +320,9 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -393,9 +393,9 @@ async def test_remove_nonexistent_pin(aresponses, v3_server, v3_settings_respons
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -438,9 +438,9 @@ async def test_remove_pin(aresponses, v3_server, v3_settings_response):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -464,9 +464,9 @@ async def test_remove_reserved_pin(aresponses, v3_server, v3_settings_response):
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -493,10 +493,10 @@ async def test_set_duplicate_pin(aresponses, v3_server, v3_settings_response):
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession
+                    TEST_EMAIL, TEST_PASSWORD, session=session
                 )
                 systems = await simplisafe.get_systems()
                 system = systems[TEST_SYSTEM_ID]
@@ -516,9 +516,9 @@ async def test_set_invalid_property(aresponses, v3_server, v3_settings_response)
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -546,10 +546,10 @@ async def test_set_max_user_pins(aresponses, v3_server, v3_settings_response):
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession
+                    TEST_EMAIL, TEST_PASSWORD, session=session
                 )
                 systems = await simplisafe.get_systems()
                 system = systems[TEST_SYSTEM_ID]
@@ -591,9 +591,9 @@ async def test_set_pin(aresponses, v3_server, v3_settings_response):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -610,10 +610,10 @@ async def test_set_pin(aresponses, v3_server, v3_settings_response):
 async def test_set_pin_wrong_chars(v3_server):
     """Test throwing an error when setting a PIN with non-digits."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession
+                    TEST_EMAIL, TEST_PASSWORD, session=session
                 )
                 systems = await simplisafe.get_systems()
                 system = systems[TEST_SYSTEM_ID]
@@ -626,10 +626,10 @@ async def test_set_pin_wrong_chars(v3_server):
 async def test_set_pin_wrong_length(v3_server):
     """Test throwing an error when setting a PIN with the wrong length."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession
+                    TEST_EMAIL, TEST_PASSWORD, session=session
                 )
                 systems = await simplisafe.get_systems()
                 system = systems[TEST_SYSTEM_ID]
@@ -678,9 +678,9 @@ async def test_set_states(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -709,9 +709,9 @@ async def test_system_notifications(aresponses, v3_server, v3_subscriptions_resp
             aresponses.Response(text=v3_subscriptions_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -738,9 +738,9 @@ async def test_system_notifications(aresponses, v3_server, v3_subscriptions_resp
 async def test_unknown_initial_state(caplog, v3_server):
     """Test handling of an initially unknown state."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             _ = await simplisafe.get_systems()
             assert any("Unknown system state" in e.message for e in caplog.records)
@@ -774,9 +774,9 @@ async def test_update_system_data(
             aresponses.Response(text=v3_settings_response, status=200),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -816,9 +816,9 @@ async def test_update_error(
             aresponses.Response(text=v3_settings_response, status=500),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,9 +31,9 @@ async def test_401_bad_credentials(aresponses):
         aresponses.Response(text="", status=401),
     )
 
-    async with aiohttp.ClientSession() as websession:
+    async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+            await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, session=session)
 
 
 @pytest.mark.asyncio
@@ -61,10 +61,10 @@ async def test_401_refresh_token_failure(
             aresponses.Response(text="", status=401),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(InvalidCredentialsError):
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, websession
+                    TEST_EMAIL, TEST_PASSWORD, session=session
                 )
 
                 systems = await simplisafe.get_systems()
@@ -115,9 +115,9 @@ async def test_401_refresh_token_success(
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -136,9 +136,9 @@ async def test_bad_request(aresponses, v2_server):
             aresponses.Response(text="", status=404),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             with pytest.raises(RequestError):
                 await simplisafe._request("get", "api/fakeEndpoint")
@@ -173,9 +173,9 @@ async def test_expired_token_refresh(aresponses, v2_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe._access_token_expire = datetime.now() - timedelta(hours=1)
             await simplisafe._request("get", "api/authCheck")
@@ -194,9 +194,11 @@ async def test_invalid_credentials(aresponses, v2_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             with pytest.raises(InvalidCredentialsError):
-                await API.login_via_credentials(TEST_EMAIL, TEST_PASSWORD, websession)
+                await API.login_via_credentials(
+                    TEST_EMAIL, TEST_PASSWORD, session=session
+                )
 
 
 @pytest.mark.asyncio
@@ -246,9 +248,9 @@ async def test_unavailable_feature_v2(
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -316,9 +318,9 @@ async def test_unavailable_feature_v3(
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -39,9 +39,9 @@ async def test_lock_unlock(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -60,9 +60,9 @@ async def test_lock_unlock(aresponses, v3_server):
 async def test_jammed(v3_server):
     """Test that a jammed lock shows the correct state."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -88,9 +88,9 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
             aresponses.Response(text="", status=401),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -107,9 +107,9 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
 async def test_properties(v3_server):
     """Test that lock properties are created properly."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -129,9 +129,9 @@ async def test_properties(v3_server):
 async def test_unknown_state(caplog, v3_server):
     """Test handling a generic error during update."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -179,9 +179,9 @@ async def test_update(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -30,9 +30,9 @@ from .common import (
 async def test_async_events(v3_server):
     """Test events with async handlers."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
@@ -81,9 +81,9 @@ async def test_async_events(v3_server):
 async def test_connect_async_success(v3_server):
     """Test triggering an async handler upon connection to the websocket."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
@@ -112,9 +112,9 @@ async def test_connect_async_success(v3_server):
 async def test_connect_sync_success(v3_server):
     """Test triggering a synchronous handler upon connection to the websocket."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
@@ -143,9 +143,9 @@ async def test_connect_sync_success(v3_server):
 async def test_connect_failure(v3_server):
     """Test connecting to the socket and an exception occurring."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio.connect = async_mock(
                 side_effect=SocketIOError()
@@ -212,9 +212,9 @@ async def test_reconnect_on_new_access_token(aresponses, v3_server):
             ),
         )
 
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
@@ -248,9 +248,9 @@ async def test_reconnect_on_new_access_token(aresponses, v3_server):
 async def test_sync_events(v3_server):
     """Test events with synchronous handlers."""
     async with v3_server:
-        async with aiohttp.ClientSession() as websession:
+        async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, websession
+                TEST_EMAIL, TEST_PASSWORD, session=session
             )
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()


### PR DESCRIPTION
**Describe what the PR does:**

This PR makes the `aiohttp` `ClientSession` an optional parameter when creating an API object.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
