### PR TITLE
Guard system properties from missing data

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -235,6 +235,13 @@ class API:  # pylint: disable=too-many-instance-attributes
 
         systems: Dict[str, System] = {}
         for system_data in subscription_resp["subscriptions"]:
+            if "version" not in system_data["location"]["system"]:
+                _LOGGER.error(
+                    "Skipping location with missing system data: %s",
+                    system_data["location"]["sid"],
+                )
+                continue
+
             version = system_data["location"]["system"]["version"]
             system_class = SYSTEM_MAP[version]
             system = system_class(

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -35,6 +35,28 @@ ENTITY_MAP: Dict[int, dict] = {
 }
 
 
+def guard_from_missing_data(default_value: Any = None):
+    """Guard a missing property by returning a set value."""
+
+    def decorator(func):
+        """Decorate."""
+
+        def wrapper(system):
+            """Call the function and handle any issue."""
+            try:
+                return func(system)
+            except KeyError as err:
+                _LOGGER.warning(
+                    "SimpliSafe didn't return data for property: %s", func.__name__
+                )
+                _LOGGER.debug(err)
+                return default_value
+
+        return wrapper
+
+    return decorator
+
+
 def create_pin_payload(pins: dict, *, version: int = VERSION_V3) -> dict:
     """Create the appropriate PIN payload for the provided version."""
     empty_user_index: int
@@ -156,7 +178,8 @@ class System:
         self.locks: Dict[str, Lock] = {}
         self.sensors: Dict[str, Union[SensorV2, SensorV3]] = {}
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def address(self) -> str:
         """Return the street address of the system.
 
@@ -164,7 +187,8 @@ class System:
         """
         return self._location_info["street1"]
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data(False)
     def alarm_going_off(self) -> bool:
         """Return whether the alarm is going off.
 
@@ -172,7 +196,8 @@ class System:
         """
         return self._location_info["system"]["isAlarming"]
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def connection_type(self) -> str:
         """Return the system's connection type (cell or WiFi).
 
@@ -188,7 +213,8 @@ class System:
         """
         return self._notifications
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def serial(self) -> str:
         """Return the system's serial number.
 
@@ -204,7 +230,8 @@ class System:
         """
         return self._state
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def system_id(self) -> int:
         """Return the SimpliSafe identifier for this system.
 
@@ -212,7 +239,8 @@ class System:
         """
         return self._location_info["sid"]
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def temperature(self) -> int:
         """Return the overall temperature measured by the system.
 
@@ -220,7 +248,8 @@ class System:
         """
         return self._location_info["system"]["temperature"]
 
-    @property
+    @property  # type: ignore
+    @guard_from_missing_data()
     def version(self) -> int:
         """Return the system version.
 

--- a/tests/fixtures/subscriptions_missing_system_response.json
+++ b/tests/fixtures/subscriptions_missing_system_response.json
@@ -1,0 +1,65 @@
+{
+    "subscriptions": [
+        {
+            "uid": 12345,
+            "sid": 12345,
+            "sStatus": 20,
+            "activated": 1445034752,
+            "planName": "24/7 Interactive Alarm Monitoring + Alerts",
+            "pinUnlocked": true,
+            "location": {
+                "sid": 12345,
+                "uid": 12345,
+                "account": 12345,
+                "street1": "1234 Main Street",
+                "street2": "",
+                "locationName": "",
+                "city": "Atlantis",
+                "state": "UW",
+                "zip": "12345",
+                "county": "SEA",
+                "notes": "",
+                "residenceType": 2,
+                "numAdults": 2,
+                "numChildren": 0,
+                "safeWord": "panic",
+                "signature": "John Allen Doe",
+                "timeZone": 2,
+                "primaryContacts": [
+                    {
+                        "name": "John Doe",
+                        "phone": "1234567890"
+                    }
+                ],
+                "secondaryContacts": [
+                    {
+                        "name": "Jane Doe",
+                        "phone": "9876543210"
+                    }
+                ],
+                "copsOptIn": false,
+                "smashSafeOptIn": false,
+                "certificateUri": "https://simplisafe.com/account2/12345/alarm-certificate",
+                "locationOffset": -360,
+                "nestStructureId": "",
+                "system": {}
+            },
+            "currency": "USD",
+            "country": "US",
+            "data": "",
+            "billDate": 1537187552,
+            "features": {
+                "monitoring": true,
+                "alerts": true,
+                "online": true,
+                "hazard": false,
+                "video": false
+            },
+            "creditCard": {
+                "type": "Mastercard",
+                "lastFour": "1234"
+            },
+            "pinUnlockedBy": "pin"
+        }
+    ]
+}


### PR DESCRIPTION
**Describe what the PR does:**

The SimpliSafe cloud can be flaky at times; often, the API doesn't return data that the system is using for its properties. Previously, accessing these properties would raise unhandled exceptions. This PR adds a guard that returns sensible default values for missing properties and logs appropriate warnings.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
