### PR TITLE
Unpin specific versions of python-socketio and python-engineio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.6.2"
 python = "^3.7.0"
-python-engineio = "=3.13.1"
-python-socketio = "=4.6.0"
+python-engineio = "^3.13.1"
+python-socketio = "^4.6.0"
 pytz = ">=2019.3,<2021.0"
 voluptuous = "^0.11.7"
 websockets = "^8.1"

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ asynctest==0.13.0
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.4.1
-python-engineio==3.12.1
-python-socketio==4.5.1
+python-engineio==3.13.1
+python-socketio==4.6.0
 pytz==2019.3
 voluptuous==0.11.7


### PR DESCRIPTION
**Describe what the PR does:**

This PR unpins specific versions of `python-socketio` and `python-engineio` (and instead merely sets minimum required versions of those libraries).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/165
Fixes https://github.com/bachya/simplisafe-python/issues/166
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
