### PR TITLE
Add new exception type for when an endpoint isn't available in the current plan

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -60,18 +60,3 @@ At any point, the "dirtiness" of the token can be checked:
     # Once the dirtiness is confirmed, the dirty bit resets:
     simplisafe.refresh_token_dirty
     # >>> False
-
-Errors/Exceptions
-*****************
-
-``simplipy`` exposes several useful error types:
-
-* :meth:`SimplipyError <simplipy.errors.SimplipyError>`: a base error that all other
-  ``simplipy`` errors inherit from
-* :meth:`RequestError <simplipy.errors.RequestError>`: an error
-  related to an invalid username/password combo
-* :meth:`PinError <simplipy.errors.PinError>`: an error related to an invalid PIN
-  operation, such as attempting to delete a reserved PIN (e.g., "master"), adding too
-  many PINs, etc.
-* :meth:`RequestError <simplipy.errors.RequestError>`: an error related to HTTP requests
-  that return something other than a ``200`` response code

--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -7,6 +7,12 @@ class SimplipyError(Exception):
     pass
 
 
+class EndpointUnavailable(SimplipyError):
+    """An error related to accessing an endpoint that isn't available in the plan."""
+
+    pass
+
+
 class InvalidCredentialsError(SimplipyError):
     """An error related to invalid credentials."""
 

--- a/tests/fixtures/unavailable_endpoint_response.json
+++ b/tests/fixtures/unavailable_endpoint_response.json
@@ -1,0 +1,7 @@
+{
+  "type": "NoRemoteManagement",
+  "message": "Subscription does not support remote management",
+  "code": "078",
+  "statusCode": 403,
+  "props": {}
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
 """Define tests for the System object."""
 # pylint: disable=protected-access
 from datetime import datetime, timedelta
-import logging
 
 import aiohttp
 from aresponses import ResponsesMockServer
@@ -189,26 +188,6 @@ async def test_expired_token_refresh(aresponses, v2_server):
 
             simplisafe._access_token_expire = datetime.now() - timedelta(hours=1)
             await simplisafe.request("post", "api/token")
-
-
-@pytest.mark.asyncio
-async def test_invalid_credentials(aresponses, v2_server):
-    """Test that invalid credentials throw the correct exception."""
-    async with ResponsesMockServer() as v2_server:
-        v2_server.add(
-            "api.simplisafe.com",
-            "/v1/api/token",
-            "post",
-            aresponses.Response(
-                text=load_fixture("invalid_credentials_response.json"), status=403,
-            ),
-        )
-
-        async with aiohttp.ClientSession() as session:
-            with pytest.raises(InvalidCredentialsError):
-                await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
-                )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds a new exception type (`EndpointUnavailable`) that gets raised when the user attempts to call an endpoint that isn't available in their plan.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
