### PR TITLE
Handle asynctest not working in Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,8 +59,8 @@ repos:
     hooks:
       - id: pydocstyle
         files: ^((aioambient|tests)/.+)?[^/]+\.py$
-  - repo: https://github.com/ryanrhee/shellcheck-py
-    rev: v0.7.1.1
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 2.1.4
     hooks:
       - id: shellcheck
         args:

--- a/tests/async_mock.py
+++ b/tests/async_mock.py
@@ -1,0 +1,9 @@
+"""Define async mocking that works for various Python versions."""
+import sys
+
+if sys.version_info[:2] < (3, 8):
+    from asynctest.mock import *  # noqa
+
+    AsyncMock = CoroutineMock  # noqa: F405
+else:
+    from unittest.mock import *  # noqa

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -5,7 +5,6 @@ import json
 from urllib.parse import urlencode
 
 import aiohttp
-from asynctest import CoroutineMock, MagicMock
 import pytest
 import pytz
 from socketio.exceptions import SocketIOError
@@ -15,7 +14,8 @@ from simplipy.entity import EntityTypes
 from simplipy.errors import WebsocketError
 from simplipy.websocket import WebsocketEvent, WebsocketWatchdog
 
-from .common import (
+from tests.async_mock import AsyncMock
+from tests.common import (
     TEST_ACCESS_TOKEN,
     TEST_CLIENT_ID,
     TEST_EMAIL,
@@ -123,7 +123,7 @@ async def test_connect_sync_success(v3_server):
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
 
-            on_connect = MagicMock()
+            on_connect = AsyncMock()
             simplisafe.websocket.on_connect(on_connect)
 
             connect_params = {
@@ -226,7 +226,7 @@ async def test_reconnect_on_new_access_token(aresponses, v3_server):
             simplisafe.websocket._sio.eio.connect = async_mock()
             simplisafe.websocket._sio.eio.disconnect = async_mock()
 
-            on_connect = MagicMock()
+            on_connect = AsyncMock()
             simplisafe.websocket.on_connect(on_connect)
 
             connect_params = {
@@ -263,9 +263,9 @@ async def test_sync_events(v3_server):
             simplisafe.websocket._sio.eio.connect = async_mock()
             simplisafe.websocket._sio.eio.disconnect = async_mock()
 
-            on_connect = MagicMock()
-            on_disconnect = MagicMock()
-            on_event = MagicMock()
+            on_connect = AsyncMock()
+            on_disconnect = AsyncMock()
+            on_event = AsyncMock()
 
             simplisafe.websocket.on_connect(on_connect)
             simplisafe.websocket.on_disconnect(on_disconnect)
@@ -305,7 +305,7 @@ async def test_sync_events(v3_server):
 @pytest.mark.asyncio
 async def test_watchdog_firing():
     """Test that the watchdog expiring fires the provided coroutine."""
-    mock_coro = CoroutineMock()
+    mock_coro = AsyncMock()
     mock_coro.__name__ = "mock_coro"
 
     watchdog = WebsocketWatchdog(mock_coro)


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes the fact that `asynctest` no longer works in Python 3.8. The PR still ensures that it can be used for Python 3.6 and 3.7.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
