### PR TITLE
Fix hidden exceptions in system.update

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -173,8 +173,8 @@ class System:
             SystemNotification
         ] = self._generate_system_notification_objects()
         self._request: Callable[..., Coroutine] = request
-        self._state: SystemStates = self._coerce_state_from_string(
-            location_info["system"]["alarmState"]
+        self._state: SystemStates = self._coerce_state_from_raw_value(
+            location_info["system"].get("alarmState")
         )
         self.locks: Dict[str, Lock] = {}
         self.sensors: Dict[str, Union[SensorV2, SensorV3]] = {}
@@ -259,8 +259,12 @@ class System:
         return self._location_info["system"]["version"]
 
     @staticmethod
-    def _coerce_state_from_string(value: str) -> SystemStates:
+    def _coerce_state_from_raw_value(value: Union[str, None]) -> SystemStates:
         """Return a proper state from a string input."""
+        if not value:
+            _LOGGER.warning("SimpliSafe didn't return current system state" "")
+            return SystemStates.unknown
+
         try:
             return SystemStates[convert_to_underscore(value)]
         except KeyError:
@@ -338,8 +342,8 @@ class System:
 
         self._location_info = location_info
         self._notifications = self._generate_system_notification_objects()
-        self._state = self._coerce_state_from_string(
-            location_info["system"]["alarmState"]
+        self._state = self._coerce_state_from_raw_value(
+            location_info["system"].get("alarmState")
         )
 
     async def _set_updated_pins(self, pins: dict) -> None:
@@ -502,21 +506,14 @@ class System:
         :param cached: Whether to used cached data.
         :type cached: ``bool``
         """
-        tasks: Dict[str, Coroutine] = {}
+        tasks: List[Coroutine] = []
+
         if include_system:
-            tasks["system"] = self._get_system_info()
+            tasks.append(self._get_system_info())
         if include_settings:
-            tasks["settings"] = self._get_settings(cached)
+            tasks.append(self._get_settings(cached))
 
-        results: List[Any] = await asyncio.gather(
-            *tasks.values(), return_exceptions=True
-        )
-
-        operation: str
-        result: dict
-        for operation, result in zip(tasks, results):
-            if isinstance(result, SimplipyError):
-                raise result
+        await asyncio.gather(*tasks)
 
         # We await entity updates after the task pool since including it can cause
         # HTTP 409s if that update occurs out of sequence:

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -262,7 +262,7 @@ class System:
     def _coerce_state_from_raw_value(value: Union[str, None]) -> SystemStates:
         """Return a proper state from a string input."""
         if not value:
-            _LOGGER.warning("SimpliSafe didn't return current system state" "")
+            _LOGGER.warning("SimpliSafe didn't return current system state")
             return SystemStates.unknown
 
         try:

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -282,7 +282,7 @@ class SystemV3(System):
 
         _LOGGER.debug('Set "%s" response: %s', value.name, state_resp)
 
-        self._state = self._coerce_state_from_string(state_resp["state"])
+        self._state = self._coerce_state_from_raw_value(state_resp["state"])
 
     async def _set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -100,6 +100,14 @@ async def test_401_refresh_token_success(
         )
         v2_server.add(
             "api.simplisafe.com",
+            "/v1/api/authCheck",
+            "get",
+            aresponses.Response(
+                text=load_fixture("auth_check_response.json"), status=200
+            ),
+        )
+        v2_server.add(
+            "api.simplisafe.com",
             f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
             aresponses.Response(text=v2_subscriptions_response, status=200,),


### PR DESCRIPTION
**Describe what the PR does:**

While diagnosing https://github.com/bachya/simplisafe-python/issues/184, I discovered that `system.update` was unintentionally throwing away exceptions that weren't based on `SimplipyError`. This could result in situations like valid `KeyErrors` that never show up; it also allowed a test to pass when it shouldn't. This PR cleans up that coroutine, fixes whatever issues it hid, and also handles https://github.com/bachya/simplisafe-python/issues/184.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/184
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
