### PR TITLE
Keep existing system state when cloud fails to return a state

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -258,12 +258,13 @@ class System:
         """
         return self._location_info["system"]["version"]
 
-    @staticmethod
-    def _coerce_state_from_raw_value(value: Union[str, None]) -> SystemStates:
+    def _coerce_state_from_raw_value(self, value: Union[str, None]) -> SystemStates:
         """Return a proper state from a string input."""
         if not value:
-            _LOGGER.warning("SimpliSafe didn't return current system state")
-            return SystemStates.unknown
+            _LOGGER.debug(
+                "SimpliSafe didn't return system state; retaining current state"
+            )
+            return self.state
 
         try:
             return SystemStates[convert_to_underscore(value)]


### PR DESCRIPTION
**Describe what the PR does:**

This PR follows up on https://github.com/bachya/simplisafe-python/pull/185 by ensuring that the existing system state is retained when the SimpliSafe cloud doesn't return a state value (which seems to be happening sporadically).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
