### PR TITLE
Clean up old/outdated linting instructions

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -34,7 +34,7 @@ MAX_PIN_LENGTH = 4
 RESERVED_PIN_LABELS = {CONF_DURESS_PIN, CONF_MASTER_PIN}
 
 
-@dataclass(frozen=True)  # pylint: disable=too-many-instance-attributes
+@dataclass(frozen=True)
 class SystemNotification:
     """Define a representation of a system notification."""
 

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -245,7 +245,7 @@ class Websocket:
             self._sync_disconnect_handler()
             self._sync_disconnect_handler = None
 
-    def async_on_connect(self, target: Callable[..., Awaitable]) -> None:  # noqa: D202
+    def async_on_connect(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called when connecting.
 
         :param target: A coroutine
@@ -259,7 +259,7 @@ class Websocket:
 
         self._sio.on("connect", _async_on_connect)
 
-    def on_connect(self, target: Callable) -> None:  # noqa: D202
+    def on_connect(self, target: Callable) -> None:
         """Define a synchronous method to be called when connecting.
 
         :param target: A synchronous function
@@ -289,7 +289,7 @@ class Websocket:
         """
         self._sync_disconnect_handler = target
 
-    def async_on_event(self, target: Callable[..., Awaitable]) -> None:  # noqa: D202
+    def async_on_event(self, target: Callable[..., Awaitable]) -> None:
         """Define a coroutine to be called an event is received.
 
         The couroutine will have a ``data`` parameter that contains the raw data from
@@ -307,7 +307,7 @@ class Websocket:
 
         self._sio.on("event", _async_on_event, namespace=self._namespace)
 
-    def on_event(self, target: Callable) -> None:  # noqa: D202
+    def on_event(self, target: Callable) -> None:
         """Define a synchronous method to be called when an event is received.
 
         The method will have a ``data`` parameter that contains the raw data from the


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes some old/outdated `pylint` and `flake8` instructions.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
