### PR TITLE
Fix incorrect V3 system cooldown units

### DIFF
--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -33,7 +33,7 @@ CONF_EXIT_DELAY_HOME = "exit_delay_home"
 CONF_LIGHT = "light"
 CONF_VOICE_PROMPT_VOLUME = "voice_prompt_volume"
 
-DEFAULT_LOCK_STATE_CHANGE_WINDOW = timedelta(minutes=15)
+DEFAULT_LOCK_STATE_CHANGE_WINDOW = timedelta(seconds=15)
 
 VOLUME_OFF = 0
 VOLUME_LOW = 1


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes an erroneous default cooldown for V3 systems with locks (15 minutes vs. 15 seconds).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
