### PR TITLE
Fix tests with latest python-socketio and python-engineio

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,7 +4,7 @@ asynctest==0.13.0
 pytest-aiohttp==0.3.0
 pytest-cov==2.8.1
 pytest==5.4.1
-python-engineio==3.13.1
-python-socketio==4.6.0
+python-engineio==4.0.0
+python-socketio==5.0.4
 pytz==2019.3
 voluptuous>=0.11.7,<0.13.0

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -39,6 +39,7 @@ async def test_async_events(v3_server):
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
             simplisafe.websocket._sio.eio.disconnect = async_mock()
+            simplisafe.websocket._sio.namespaces = {"/": 1}
 
             on_connect = async_mock()
             on_disconnect = async_mock()
@@ -90,6 +91,7 @@ async def test_connect_async_success(v3_server):
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
+            simplisafe.websocket._sio.namespaces = {"/": 1}
 
             on_connect = async_mock()
             simplisafe.websocket.async_on_connect(on_connect)
@@ -122,6 +124,7 @@ async def test_connect_sync_success(v3_server):
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
+            simplisafe.websocket._sio.namespaces = {"/": 1}
 
             on_connect = AsyncMock()
             simplisafe.websocket.on_connect(on_connect)
@@ -225,6 +228,7 @@ async def test_reconnect_on_new_access_token(aresponses, v3_server):
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
             simplisafe.websocket._sio.eio.disconnect = async_mock()
+            simplisafe.websocket._sio.namespaces = {"/": 1}
 
             on_connect = AsyncMock()
             simplisafe.websocket.on_connect(on_connect)
@@ -262,6 +266,7 @@ async def test_sync_events(v3_server):
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
             simplisafe.websocket._sio.eio.connect = async_mock()
             simplisafe.websocket._sio.eio.disconnect = async_mock()
+            simplisafe.websocket._sio.namespaces = {"/": 1}
 
             on_connect = AsyncMock()
             on_disconnect = AsyncMock()


### PR DESCRIPTION
**Describe what the PR does:**

This PR fixes tests that would be broken with the latest versions of `python-socketio` and `python-engineio` (which were not actively being used).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
