### PR TITLE
Overhaul request retry mechanism

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -41,7 +41,7 @@ when it comes time to re-authenticate, simply:
 .. code:: python
 
     simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", client_id="<UNIQUE IDENTIFIER>", session=session
+        "<REFRESH TOKEN>", session=session, client_id="<UNIQUE IDENTIFIER>"
     )
 
 During usage, ``simplipy`` will automatically refresh the access token as needed.
@@ -50,7 +50,7 @@ At any point, the "dirtiness" of the token can be checked:
 .. code:: python
 
     simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", client_id="<UNIQUE IDENTIFIER>", session=session
+        "<REFRESH TOKEN>", session=session, client_id="<UNIQUE IDENTIFIER>"
     )
 
     # Assuming the access token was automatically refreshed:

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -29,8 +29,8 @@ To get all SimpliSafe™ systems associated with an account:
             simplisafe = await simplipy.API.login_via_credentials(
                 "<EMAIL>",
                 "<PASSWORD>",
-                client_id="<UNIQUE IDENTIFIER>",
                 session=session
+                client_id="<UNIQUE IDENTIFIER>",
             )
 
             # Get a dict of systems with the system ID as the key:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -133,8 +133,8 @@ The primary way of creating an API object is via the
             simplisafe = await API.login_via_credentials(
                 "<EMAIL>",
                 "<PASSWORD>",
-                client_id="<UNIQUE IDENTIFIER>",
                 session=session,
+                client_id="<UNIQUE IDENTIFIER>",
             )
 
             # ...
@@ -171,8 +171,8 @@ token) to achieve connection pooling:
             simplisafe = await API.login_via_credentials(
                 "<EMAIL>",
                 "<PASSWORD>",
-                client_id="<UNIQUE IDENTIFIER>",
                 session=session,
+                client_id="<UNIQUE IDENTIFIER>",
             )
 
             # ...

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -48,7 +48,7 @@ async def test_get_events(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -88,7 +88,7 @@ async def test_properties(v2_server):
     async with v2_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -111,7 +111,7 @@ async def test_unknown_sensor_type(caplog, v2_server):
     async with v2_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             await simplisafe.get_systems()

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -32,7 +32,7 @@ async def test_get_pins(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -86,7 +86,7 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -139,7 +139,7 @@ async def test_get_systems_via_token(aresponses, v2_server, v2_subscriptions_res
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_token(
-                TEST_REFRESH_TOKEN, client_id=TEST_CLIENT_ID, session=session
+                TEST_REFRESH_TOKEN, session=session, client_id=TEST_CLIENT_ID
             )
             systems = await simplisafe.get_systems()
             assert len(systems) == 1
@@ -186,7 +186,7 @@ async def test_set_pin(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -242,7 +242,7 @@ async def test_set_states(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -282,7 +282,7 @@ async def test_update_system_data(aresponses, v2_server, v2_subscriptions_respon
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -38,7 +38,13 @@ async def test_401_bad_credentials(aresponses):
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
             await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL,
+                TEST_PASSWORD,
+                session=session,
+                client_id=TEST_CLIENT_ID,
+                # We pass a small retry interval pair to ensure this test doesn't
+                # hang for a long time:
+                request_retry_interval=0,
             )
 
 
@@ -70,7 +76,13 @@ async def test_401_refresh_token_failure(
         async with aiohttp.ClientSession() as session:
             with pytest.raises(InvalidCredentialsError):
                 simplisafe = await API.login_via_credentials(
-                    TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                    TEST_EMAIL,
+                    TEST_PASSWORD,
+                    session=session,
+                    client_id=TEST_CLIENT_ID,
+                    # We pass a small retry interval pair to ensure this test doesn't
+                    # hang for a long time:
+                    request_retry_interval=0,
                 )
 
                 systems = await simplisafe.get_systems()
@@ -123,7 +135,13 @@ async def test_401_refresh_token_success(
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL,
+                TEST_PASSWORD,
+                session=session,
+                client_id=TEST_CLIENT_ID,
+                # We pass a small retry interval pair to ensure this test doesn't
+                # hang for a long time:
+                request_retry_interval=0,
             )
             assert simplisafe.client_id == TEST_CLIENT_ID
 
@@ -146,7 +164,7 @@ async def test_403_bad_credentials(aresponses):
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
             await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
 
@@ -163,7 +181,13 @@ async def test_bad_request(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL,
+                TEST_PASSWORD,
+                session=session,
+                client_id=TEST_CLIENT_ID,
+                # We pass a small retry interval pair to ensure this test doesn't
+                # hang for a long time:
+                request_retry_interval=0,
             )
 
             with pytest.raises(RequestError):
@@ -209,7 +233,7 @@ async def test_expired_token_refresh(aresponses, v2_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe._access_token_expire = datetime.now() - timedelta(hours=1)
@@ -247,5 +271,5 @@ async def test_mfa(aresponses):
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PendingAuthorizationError):
             await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=None, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=None
             )

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -29,7 +29,7 @@ async def test_properties(aresponses, v3_server, v3_subscriptions_response):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -64,7 +64,7 @@ async def test_video_urls(aresponses, v3_server, v3_subscriptions_response):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -42,7 +42,7 @@ async def test_lock_unlock(aresponses, v3_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -64,7 +64,7 @@ async def test_jammed(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -93,7 +93,7 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -113,7 +113,7 @@ async def test_properties(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -136,7 +136,7 @@ async def test_unknown_state(caplog, v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()
@@ -187,7 +187,7 @@ async def test_update(aresponses, v3_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             systems = await simplisafe.get_systems()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -33,7 +33,7 @@ async def test_async_events(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
@@ -86,7 +86,7 @@ async def test_connect_async_success(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
@@ -119,7 +119,7 @@ async def test_connect_sync_success(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
@@ -152,7 +152,7 @@ async def test_connect_failure(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio.connect = async_mock(
@@ -222,7 +222,7 @@ async def test_reconnect_on_new_access_token(aresponses, v3_server):
 
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()
@@ -260,7 +260,7 @@ async def test_sync_events(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
+                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
             simplisafe.websocket._sio.eio._trigger_event = async_mock()


### PR DESCRIPTION
**Describe what the PR does:**

The previous manner for handling request retries (specifically, in the case of `401` responses) was fairly brittle and one-shot-ish. This PR puts an official request retry mechanism in place.

As a side effect, this should help uses who are currently getting bitten by the flakiness of SimpliSafe's cloud API and how, over the past several months, it can tend to return `409`/`500`/`502` responses during critical activities (like arming the alarm).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
