### PR TITLE
Fix bug with refreshing 401

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -295,6 +295,17 @@ class API:  # pylint: disable=too-many-instance-attributes
 
                     LOGGER.debug("Data received from /%s: %s", endpoint, data)
 
+                    if isinstance(data, str):
+                        # In some cases, the SimpliSafe API will return a quoted string
+                        # in its response body (e.g., "\"node not found\""), which is
+                        # technically valid JSON. Additionally, SimpliSafe sets that
+                        # response's Content-Type header to application/json (#smh).
+                        # Together, these factors will allow a non-true-JSON  payload to
+                        # escape the try/except above. So, if we get here, we use the
+                        # string value (with quotes removed) to raise an error:
+                        message = data.replace('"', "")
+                        data = {"error": message}
+
                     resp.raise_for_status()
                     return data
             except ClientError as err:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -32,7 +32,7 @@ async def test_401_bad_credentials(aresponses):
         "api.simplisafe.com",
         "/v1/api/token",
         "post",
-        aresponses.Response(text="Unauthorized", status=401),
+        aresponses.Response(text='"Unauthorized"', status=401),
     )
 
     async with aiohttp.ClientSession() as session:
@@ -64,13 +64,13 @@ async def test_401_refresh_token_failure(
             "api.simplisafe.com",
             f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
             "get",
-            aresponses.Response(text="Unauthorized", status=401),
+            aresponses.Response(text='"Unauthorized"', status=401),
         )
         v2_server.add(
             "api.simplisafe.com",
             "/v1/api/token",
             "post",
-            aresponses.Response(text="Unauthorized", status=401),
+            aresponses.Response(text='"Unauthorized"', status=401),
         )
 
         async with aiohttp.ClientSession() as session:
@@ -100,7 +100,7 @@ async def test_401_refresh_token_success(
             "api.simplisafe.com",
             f"/v1/users/{TEST_USER_ID}/subscriptions",
             "get",
-            aresponses.Response(text="Unauthorized", status=401),
+            aresponses.Response(text='"Unauthorized"', status=401),
         )
         v2_server.add(
             "api.simplisafe.com",


### PR DESCRIPTION
**Describe what the PR does:**

After #222 and #223, I noticed this error in the Home Assistant logs every so often:

```
AttributeError: 'str' object has no attribute 'get'
```

I realized that when SimpliSafe returns a 401 response, I gives an escaped-string response body:

```
HTTP/1.1 401 Unauthorized
Date: Tue, 02 Mar 2021 04:59:01 GMT
Content-Type: application/json; charset=utf-8
Content-Length: 14
Connection: close
...

"Unauthorized"
```

Because the body is an escaped string, it is technically valid JSON and was therefore skipping the logic designed to catch non-JSON responses. This PR fixes the issue and updates the tests to ensure we properly test what a 401 response _actually_ looks like.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
