### PR TITLE
Fix incorrect exception error verbiage

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -347,7 +347,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     await session.close()
 
         raise RequestError(
-            f"Requesting /{endpoint} failed after {retries + 1} tries"
+            f"Requesting /{endpoint} failed after {retries} tries"
         ) from None
 
     async def refresh_access_token(self, refresh_token: Optional[str]) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

The `RequestError` thrown when all request retries expire showed incorrect verbiage (the number of total retries was one too many). This PR fixes that verbiage.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
