### PR TITLE
Fix bug with setting PINs in v3 systems

### DIFF
--- a/examples/test_pins.py
+++ b/examples/test_pins.py
@@ -1,0 +1,38 @@
+"""Run an example script to interact with locks."""
+import asyncio
+import logging
+
+from aiohttp import ClientSession
+
+from simplipy import API
+from simplipy.errors import SimplipyError
+
+_LOGGER = logging.getLogger()
+
+SIMPLISAFE_CLIENT_ID = "<CLIENT ID>"
+SIMPLISAFE_EMAIL = "<EMAIL>"  # nosec
+SIMPLISAFE_PASSWORD = "<PASSWORD>"  # nosec
+
+
+async def main() -> None:
+    """Create the aiohttp session and run the example."""
+    async with ClientSession() as session:
+        logging.basicConfig(level=logging.DEBUG)
+
+        try:
+            simplisafe = await API.login_via_credentials(
+                SIMPLISAFE_EMAIL,
+                SIMPLISAFE_PASSWORD,
+                client_id=SIMPLISAFE_CLIENT_ID,
+                session=session,
+            )
+            systems = await simplisafe.get_systems()
+            for system in systems.values():
+                await system.set_pin("Test PIN", "1235")
+                await asyncio.sleep(3)
+                await system.remove_pin("Test PIN")
+        except SimplipyError as err:
+            _LOGGER.error(err)
+
+
+asyncio.run(main())

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -1,6 +1,7 @@
 """Define a V2 (original) SimpliSafe system."""
 from typing import Dict
 
+from simplipy.const import LOGGER
 from simplipy.sensor.v2 import SensorV2
 from simplipy.system import (
     CONF_DURESS_PIN,
@@ -30,6 +31,8 @@ def create_pin_payload(pins: dict) -> Dict[str, Dict[str, Dict[str, str]]]:
             "name": "",
             "pin": "",
         }
+
+    LOGGER.debug("PIN payload: %s", payload)
 
     return payload
 

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -103,7 +103,9 @@ def create_pin_payload(pins: dict) -> Dict[str, Dict[str, Dict[str, str]]]:
             "pin": "",
         }
 
-    payload["users"] = user_pins
+    payload["pins"]["users"] = user_pins
+
+    LOGGER.debug("PIN payload: %s", payload)
 
     return payload
 


### PR DESCRIPTION
**Describe what the PR does:**

Recently, attempting to set a PIN resulted in this `DEBUG`-level log message:

```
DEBUG:simplipy:Data received from /ss3/subscriptions/XXXXXX/settings/pins: {'type': 'PinError', 'message': 'You must have at least 4 user pins', 'code': '206', 'statusCode': 400, 'props': {}}
```

Some investigation revealed that SimpliSafe changed the request payload to set PINs in v3 systems. This PR makes the appropriate update.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/228
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
