### PR TITLE
Don't initialize websocket by default

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -226,7 +226,9 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.user_id = auth_check_resp["userId"]
 
         # Start the websocket:
-        await self.websocket.async_init(self._access_token, self.user_id)
+        # NOTE (2021-05-02): The SimpliSafe websocket has changed and no suitable
+        # replacement has been found; disabling for now:
+        # await self.websocket.async_init(self._access_token, self.user_id)
 
     async def get_systems(self) -> Dict[int, Union[SystemV2, SystemV3]]:
         """Get systems associated to the associated SimpliSafe account.


### PR DESCRIPTION
**Describe what the PR does:**

Because of https://github.com/bachya/simplisafe-python/issues/226, we shouldn't automatically initialize the websocket anymore. Hopefully, a workaround will be found.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
