### PR TITLE
Make references to refresh token private

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -17,46 +17,13 @@ usage of these properties is solely your responsibility.**
 .. code:: python
 
     # Return the current access token:
-    simplisafe.access_token
+    simplisafe._access_token
     # >>> 7s9yasdh9aeu21211add
 
     # Return the current refresh token:
-    simplisafe.refresh_token
+    simplisafe._refresh_token
     # >>> 896sad86gudas87d6asd
 
     # Return the SimpliSafe™ user ID associated with this account:
     simplisafe.user_id
     # >>> 1234567
-
-.. _refreshing-access-tokens:
-
-Refreshing Access Tokens
-************************
-
-It may be desirable to re-authenticate against the SimpliSafe™ API at some
-point in the future (and without using a user's email and password). In that
-case, it is recommended that you save the ``refresh_token`` property somewhere;
-when it comes time to re-authenticate, simply:
-
-.. code:: python
-
-    simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", session=session, client_id="<UNIQUE IDENTIFIER>"
-    )
-
-During usage, ``simplipy`` will automatically refresh the access token as needed.
-At any point, the "dirtiness" of the token can be checked:
-
-.. code:: python
-
-    simplisafe = await simplipy.API.login_via_token(
-        "<REFRESH TOKEN>", session=session, client_id="<UNIQUE IDENTIFIER>"
-    )
-
-    # Assuming the access token was automatically refreshed:
-    simplisafe.refresh_token_dirty
-    # >>> True
-
-    # Once the dirtiness is confirmed, the dirty bit resets:
-    simplisafe.refresh_token_dirty
-    # >>> False

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -144,18 +144,14 @@ The primary way of creating an API object is via the
 
 Note that the multi-factor authentication unique identifier is passed to the coroutine.
 
-You can also use the
-:meth:`API.login_via_token <simplipy.api.API.login_via_token>` coroutine, which is
-detailed in :ref:`refreshing-access-tokens`.
-
 Connection Pooling
 ------------------
 
 By default, the :meth:`API <simplipy.api.API>` object creates a new connection to
 SimpliSafe™ with each coroutine. If you are calling a large number of coroutines (or
 merely want to squeeze out every second of runtime savings possible), an
-``aiohttp ClientSession`` can be supplied when logging into the API (via credentials or
-token) to achieve connection pooling:
+``aiohttp ClientSession`` can be supplied when logging into the API to achieve
+connection pooling:
 
 .. code:: python
 

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -71,7 +71,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         """Initialize."""
         self._client_id = client_id or str(uuid4())
         self._refresh_tried: bool = False
-        self._request_retry_interval = request_retry_interval
+        self.request_retry_interval = request_retry_interval
         self._session: ClientSession = session
 
         # These will get filled in after initial authentication:
@@ -99,89 +99,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         """Return the client ID of the API."""
         return self._client_id
 
-    @property
-    def refresh_token(self) -> Optional[str]:
-        """Return the current refresh token.
-
-        :rtype: ``str``
-        """
-        return self._refresh_token
-
-    @classmethod
-    async def login_via_credentials(
-        cls: Type[ApiType],
-        email: str,
-        password: str,
-        *,
-        session: Optional[ClientSession] = None,
-        client_id: Optional[str] = None,
-        request_retry_interval: int = DEFAULT_REQUEST_RETRY_INTERVAL,
-    ) -> ApiType:
-        """Create an API object from a email address and password.
-
-        :param email: A SimpliSafe email address
-        :type email: ``str``
-        :param password: A SimpliSafe password
-        :type password: ``str``
-        :param session: An ``aiohttp`` ``ClientSession``
-        :type session: ``aiohttp.client.ClientSession``
-        :param client_id: The SimpliSafe client ID to use for this API object
-        :type client_id: ``str``
-        :param request_retry_interval: The number of seconds between request retries
-        :type client_id: ``int``
-        :rtype: :meth:`simplipy.API`
-        """
-        instance = cls(
-            session=session,
-            client_id=client_id,
-            request_retry_interval=request_retry_interval,
-        )
-        instance.email = email
-
-        await instance.authenticate(
-            {
-                "grant_type": "password",
-                "username": email,
-                "password": password,
-                "client_id": instance.client_id_string,
-                "device_id": instance.device_id_string,
-                "app_version": DEFAULT_APP_VERSION,
-                "scope": "offline_access",
-            }
-        )
-
-        return instance
-
-    @classmethod
-    async def login_via_token(
-        cls: Type[ApiType],
-        refresh_token: str,
-        *,
-        session: Optional[ClientSession] = None,
-        client_id: Optional[str] = None,
-        request_retry_interval: int = DEFAULT_REQUEST_RETRY_INTERVAL,
-    ) -> ApiType:
-        """Create an API object from a refresh token.
-
-        :param refresh_token: A SimpliSafe refresh token
-        :type refresh_token: ``str``
-        :param session: An ``aiohttp`` ``ClientSession``
-        :type session: ``aiohttp.client.ClientSession``
-        :param client_id: The SimpliSafe client ID to use for this API object
-        :type client_id: ``str``
-        :param request_retry_interval: The number of seconds between request retries
-        :type client_id: ``int``
-        :rtype: :meth:`simplipy.API`
-        """
-        instance = cls(
-            session=session,
-            client_id=client_id,
-            request_retry_interval=request_retry_interval,
-        )
-        await instance.refresh_access_token(refresh_token)
-        return instance
-
-    async def authenticate(self, payload: dict) -> None:
+    async def _authenticate(self, payload: dict) -> None:
         """Authenticate the API object using an authentication payload."""
         LOGGER.debug("Authentication payload: %s", payload)
 
@@ -222,6 +140,65 @@ class API:  # pylint: disable=too-many-instance-attributes
         # Fetch the SimpliSafe user ID:
         auth_check_resp = await self.request("get", "api/authCheck")
         self.user_id = auth_check_resp["userId"]
+
+    async def _refresh_access_token(self, refresh_token: Optional[str]) -> None:
+        """Regenerate an access token.
+
+        :param refresh_token: The refresh token to use
+        :type refresh_token: str
+        """
+        await self._authenticate(
+            {
+                "grant_type": "refresh_token",
+                "client_id": self._client_id,
+                "refresh_token": refresh_token,
+            }
+        )
+
+    @classmethod
+    async def login_via_credentials(
+        cls: Type[ApiType],
+        email: str,
+        password: str,
+        *,
+        session: Optional[ClientSession] = None,
+        client_id: Optional[str] = None,
+        request_retry_interval: int = DEFAULT_REQUEST_RETRY_INTERVAL,
+    ) -> ApiType:
+        """Create an API object from a email address and password.
+
+        :param email: A SimpliSafe email address
+        :type email: ``str``
+        :param password: A SimpliSafe password
+        :type password: ``str``
+        :param session: An ``aiohttp`` ``ClientSession``
+        :type session: ``aiohttp.client.ClientSession``
+        :param client_id: The SimpliSafe client ID to use for this API object
+        :type client_id: ``str``
+        :param request_retry_interval: The number of seconds between request retries
+        :type client_id: ``int``
+        :rtype: :meth:`simplipy.API`
+        """
+        instance = cls(
+            session=session,
+            client_id=client_id,
+            request_retry_interval=request_retry_interval,
+        )
+        instance.email = email
+
+        await instance._authenticate(
+            {
+                "grant_type": "password",
+                "username": email,
+                "password": password,
+                "client_id": instance.client_id_string,
+                "device_id": instance.device_id_string,
+                "app_version": DEFAULT_APP_VERSION,
+                "scope": "offline_access",
+            }
+        )
+
+        return instance
 
     async def get_systems(self) -> Dict[int, Union[SystemV2, SystemV3]]:
         """Get systems associated to the associated SimpliSafe account.
@@ -324,7 +301,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     if self._refresh_token and not self._refresh_tried:
                         LOGGER.info("401 detected; attempting refresh token")
                         self._refresh_tried = True
-                        await self.refresh_access_token(self._refresh_token)
+                        await self._refresh_access_token(self._refresh_token)
 
                 if "403" in str(err):
                     raise InvalidCredentialsError("Invalid username/password") from None
@@ -337,7 +314,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                     DEFAULT_REQUEST_RETRIES,
                 )
                 retries += 1
-                await asyncio.sleep(self._request_retry_interval)
+                await asyncio.sleep(self.request_retry_interval)
             finally:
                 if not use_running_session:
                     await session.close()
@@ -345,20 +322,6 @@ class API:  # pylint: disable=too-many-instance-attributes
         raise RequestError(
             f"Requesting /{endpoint} failed after {retries} tries"
         ) from None
-
-    async def refresh_access_token(self, refresh_token: Optional[str]) -> None:
-        """Regenerate an access token.
-
-        :param refresh_token: The refresh token to use
-        :type refresh_token: str
-        """
-        await self.authenticate(
-            {
-                "grant_type": "refresh_token",
-                "client_id": self._client_id,
-                "refresh_token": refresh_token,
-            }
-        )
 
     async def update_subscription_data(self) -> None:
         """Update our internal "raw data" listing of subscriptions."""

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -50,8 +50,7 @@ class API:  # pylint: disable=too-many-instance-attributes
     """An API object to interact with the SimpliSafe cloud.
 
     Note that this class shouldn't be instantiated directly; instead, the
-    :meth:`simplipy.API.login_via_credentials` and :meth:`simplipy.API.login_via_token`
-    class methods should be used.
+    :meth:`simplipy.API.login_via_credentials` class method should be used.
 
     :param session: The ``aiohttp`` ``ClientSession`` session used for all HTTP requests
     :type session: ``aiohttp.client.ClientSession``

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -100,58 +100,6 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
 
 
 @pytest.mark.asyncio
-async def test_get_systems_via_token(aresponses, v2_server, v2_subscriptions_response):
-    """Test the ability to get systems attached to a v2 account."""
-    async with v2_server:
-        # Since this flow will call both three routes once more each (on top of
-        # what instantiation does) and aresponses deletes matches each time,
-        # we need to add additional routes:
-        v2_server.add(
-            "api.simplisafe.com",
-            "/v1/api/token",
-            "post",
-            aresponses.Response(
-                text=load_fixture("api_token_response.json"), status=200
-            ),
-        )
-        v2_server.add(
-            "api.simplisafe.com",
-            "/v1/api/authCheck",
-            "get",
-            aresponses.Response(
-                text=load_fixture("auth_check_response.json"), status=200
-            ),
-        )
-        v2_server.add(
-            "api.simplisafe.com",
-            f"/v1/users/{TEST_USER_ID}/subscriptions",
-            "get",
-            aresponses.Response(text=v2_subscriptions_response, status=200),
-        )
-        v2_server.add(
-            "api.simplisafe.com",
-            f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/settings",
-            "get",
-            aresponses.Response(
-                text=load_fixture("v2_settings_response.json"), status=200
-            ),
-        )
-
-        async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_token(
-                TEST_REFRESH_TOKEN, session=session, client_id=TEST_CLIENT_ID
-            )
-            systems = await simplisafe.get_systems()
-            assert len(systems) == 1
-
-            system = systems[TEST_SYSTEM_ID]
-            assert system.serial == TEST_SYSTEM_SERIAL_NO
-            assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
-            assert len(system.sensors) == 35
-
-
-@pytest.mark.asyncio
 async def test_set_pin(aresponses, v2_server):
     """Test setting a PIN in a V2 system."""
     async with v2_server:

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -224,67 +224,6 @@ async def test_get_systems(
 
 
 @pytest.mark.asyncio
-async def test_get_systems_via_token(
-    aresponses, v3_server, v3_subscriptions_response, v3_settings_response
-):
-    """Test the ability to get systems attached to a v3 account when logging in via token."""
-    async with v3_server:
-        # Since this flow will call both three routes once more each (on top of
-        # what instantiation does) and aresponses deletes matches each time,
-        # we need to add additional routes:
-        v3_server.add(
-            "api.simplisafe.com",
-            "/v1/api/token",
-            "post",
-            aresponses.Response(
-                text=load_fixture("api_token_response.json"), status=200
-            ),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            "/v1/api/authCheck",
-            "get",
-            aresponses.Response(
-                text=load_fixture("auth_check_response.json"), status=200
-            ),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/users/{TEST_USER_ID}/subscriptions",
-            "get",
-            aresponses.Response(text=v3_subscriptions_response, status=200),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/sensors",
-            "get",
-            aresponses.Response(
-                text=load_fixture("v3_sensors_response.json"), status=200
-            ),
-        )
-        v3_server.add(
-            "api.simplisafe.com",
-            f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/settings/normal",
-            "get",
-            aresponses.Response(text=v3_settings_response, status=200),
-        )
-
-        async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_token(
-                TEST_REFRESH_TOKEN, session=session, client_id=TEST_CLIENT_ID
-            )
-            systems = await simplisafe.get_systems()
-            assert len(systems) == 1
-
-            system = systems[TEST_SYSTEM_ID]
-
-            assert system.serial == TEST_SYSTEM_SERIAL_NO
-            assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
-            assert len(system.sensors) == 24
-
-
-@pytest.mark.asyncio
 async def test_empty_events(aresponses, v3_server):
     """Test that an empty events structure is handled correctly."""
     async with v3_server:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -148,7 +148,7 @@ async def test_401_refresh_token_success(
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
             await system.update()
-            assert simplisafe.refresh_token == TEST_REFRESH_TOKEN
+            assert simplisafe._refresh_token == TEST_REFRESH_TOKEN
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Because the SimpliSafe refresh token can sometimes fail for no apparent reason, I'm realizing that we shouldn't expose it (or any methods for using it) to the user; instead, we should handle all forms of reauthentication (refresh token, full-on credentials) underneath the hood.

This PR takes the first step by making any references to the refresh token private; it also removes the `API.login_via_token` method.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
