### PR TITLE
Rework getting an authenticated API object

### DIFF
--- a/docs/system.rst
+++ b/docs/system.rst
@@ -26,7 +26,7 @@ To get all SimpliSafe™ systems associated with an account:
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await simplipy.API.login_via_credentials(
+            simplisafe = await simplipy.get_api(
                 "<EMAIL>",
                 "<PASSWORD>",
                 session=session

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -41,7 +41,7 @@ Accessing the API
 -----------------
 
 The usual way to create an API object is via the
-:meth:`API.login_via_credentials <simplipy.api.API.login_via_credentials>` coroutine. In
+:meth:`get_api <simplipy.api.get_api>` coroutine. In
 order to use it effectively, you must first walk through SimpliSafe™'s multi-factor
 authentication flow.
 
@@ -117,7 +117,7 @@ Creating an API Object
 **********************
 
 The primary way of creating an API object is via the
-:meth:`API.login_via_credentials <simplipy.api.API.login_via_credentials>` coroutine:
+:meth:`get_api <simplipy.api.get_api>` coroutine:
 
 .. code:: python
 
@@ -130,7 +130,7 @@ The primary way of creating an API object is via the
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await simplipy.get_api(
                 "<EMAIL>",
                 "<PASSWORD>",
                 session=session,
@@ -164,7 +164,7 @@ connection pooling:
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await simplipy.get_api(
                 "<EMAIL>",
                 "<PASSWORD>",
                 session=session,

--- a/examples/test_events.py
+++ b/examples/test_events.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 
 _LOGGER = logging.getLogger()
@@ -20,7 +20,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/examples/test_locks.py
+++ b/examples/test_locks.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 from simplipy.lock import LockStates
 
@@ -21,7 +21,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/examples/test_pins.py
+++ b/examples/test_pins.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 
 _LOGGER = logging.getLogger()
@@ -20,7 +20,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.DEBUG)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/examples/test_sensor_properties.py
+++ b/examples/test_sensor_properties.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 
 _LOGGER = logging.getLogger()
@@ -20,7 +20,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/examples/test_sensor_types.py
+++ b/examples/test_sensor_types.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import RequestError, SimplipyError
 
 _LOGGER = logging.getLogger()
@@ -20,7 +20,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.DEBUG)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/examples/test_system_state.py
+++ b/examples/test_system_state.py
@@ -4,7 +4,7 @@ import logging
 
 from aiohttp import ClientSession
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 
 _LOGGER = logging.getLogger()
@@ -20,7 +20,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 SIMPLISAFE_EMAIL,
                 SIMPLISAFE_PASSWORD,
                 client_id=SIMPLISAFE_CLIENT_ID,

--- a/script/mfa
+++ b/script/mfa
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import sys
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import PendingAuthorizationError
 
 
@@ -17,7 +17,7 @@ async def main() -> None:
             password = input("What is your SimpliSafe email password? ")
             client_id = input("(optional) What is your SimpliSafe client ID? ")
 
-            await API.login_via_credentials(
+            await get_api(
                 email, password, client_id=client_id or None
             )
         except PendingAuthorizationError as err:

--- a/simplipy/__init__.py
+++ b/simplipy/__init__.py
@@ -1,2 +1,2 @@
 """Define module-level imports."""
-from .api import API  # noqa
+from .api import get_api  # noqa

--- a/tests/sensor/__init__.py
+++ b/tests/sensor/__init__.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.entity import EntityTypes
 
 from tests.common import TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
@@ -13,9 +13,7 @@ async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, session
-            )
+            simplisafe = await get_api(TEST_EMAIL, TEST_PASSWORD, session)
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
 

--- a/tests/sensor/test_base.py
+++ b/tests/sensor/test_base.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.entity import EntityTypes
 
 from tests.common import TEST_CLIENT_ID, TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
@@ -13,7 +13,7 @@ async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 

--- a/tests/sensor/test_v2.py
+++ b/tests/sensor/test_v2.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import SimplipyError
 
 from tests.common import TEST_CLIENT_ID, TEST_EMAIL, TEST_PASSWORD, TEST_SYSTEM_ID
@@ -13,7 +13,7 @@ async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 

--- a/tests/sensor/test_v3.py
+++ b/tests/sensor/test_v3.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.entity import EntityTypes
 from simplipy.errors import SimplipyError
 
@@ -14,7 +14,7 @@ async def test_properties_base(v2_server):
     """Test that base sensor properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 
@@ -32,7 +32,7 @@ async def test_properties_v2(v2_server):
     """Test that v2 sensor properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 
@@ -64,7 +64,7 @@ async def test_properties_v3(v3_server):
     """Test that v3 sensor properties are created properly."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 
@@ -96,7 +96,7 @@ async def test_unknown_sensor_type(caplog, v2_server):
     """Test that a message is logged when unknown sensors types are found."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID, session=session
             )
 

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.system import SystemStates
 
 from tests.common import (
@@ -26,9 +26,7 @@ from tests.common import (
 async def test_deactivated_system(v3_server):
     """Test that API.get_systems doesn't return deactivated systems."""
     async with v3_server:
-        simplisafe = await API.login_via_credentials(
-            TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID
-        )
+        simplisafe = await get_api(TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID)
 
         systems = await simplisafe.get_systems()
 
@@ -47,7 +45,7 @@ async def test_get_events(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -70,9 +68,7 @@ async def test_get_events_no_explicit_session(aresponses, v2_server):
             aresponses.Response(text=load_fixture("events_response.json"), status=200),
         )
 
-        simplisafe = await API.login_via_credentials(
-            TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID
-        )
+        simplisafe = await get_api(TEST_EMAIL, TEST_PASSWORD, client_id=TEST_CLIENT_ID)
 
         systems = await simplisafe.get_systems()
         system = systems[TEST_SYSTEM_ID]
@@ -87,7 +83,7 @@ async def test_properties(v2_server):
     """Test that base system properties are created properly."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -110,7 +106,7 @@ async def test_unknown_sensor_type(caplog, v2_server):
     """Test whether a message is logged upon finding an unknown sensor type."""
     async with v2_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.system import SystemStates
 
 from tests.common import (
@@ -31,7 +31,7 @@ async def test_get_pins(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -85,7 +85,7 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -95,7 +95,7 @@ async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
             system = systems[TEST_SYSTEM_ID]
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
+            assert simplisafe._access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35
 
 
@@ -133,7 +133,7 @@ async def test_set_pin(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -189,7 +189,7 @@ async def test_set_states(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -229,7 +229,7 @@ async def test_update_system_data(aresponses, v2_server, v2_subscriptions_respon
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -240,5 +240,5 @@ async def test_update_system_data(aresponses, v2_server, v2_subscriptions_respon
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
+            assert simplisafe._access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 35

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -6,7 +6,7 @@ import aiohttp
 import pytest
 import pytz
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import (
     EndpointUnavailable,
     InvalidCredentialsError,
@@ -50,7 +50,7 @@ async def test_409_during_arming(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL,
                 TEST_PASSWORD,
                 session=session,
@@ -75,7 +75,7 @@ async def test_alarm_state(v3_server):
     """Test handling of a triggered alarm."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -98,7 +98,7 @@ async def test_clear_notifications(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -123,7 +123,7 @@ async def test_get_last_event(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -146,7 +146,7 @@ async def test_get_pins(aresponses, v3_server, v3_settings_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -208,7 +208,7 @@ async def test_get_systems(
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -219,7 +219,7 @@ async def test_get_systems(
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
+            assert simplisafe._access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 24
 
 
@@ -237,7 +237,7 @@ async def test_empty_events(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -265,7 +265,7 @@ async def test_lock_state_update_bug(aresponses, caplog, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -292,7 +292,7 @@ async def test_missing_events(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -312,7 +312,7 @@ async def test_missing_system_info_initial(caplog, v3_server):
     """Test that missing system data on system load is handled correctly."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -343,7 +343,7 @@ async def test_missing_property(
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -377,7 +377,7 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -403,7 +403,7 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -477,7 +477,7 @@ async def test_remove_nonexistent_pin(aresponses, v3_server, v3_settings_respons
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -523,7 +523,7 @@ async def test_remove_pin(aresponses, v3_server, v3_settings_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -550,7 +550,7 @@ async def test_remove_reserved_pin(aresponses, v3_server, v3_settings_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -581,7 +581,7 @@ async def test_set_duplicate_pin(aresponses, v3_server, v3_settings_response):
 
         async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
-                simplisafe = await API.login_via_credentials(
+                simplisafe = await get_api(
                     TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
                 )
 
@@ -604,7 +604,7 @@ async def test_set_invalid_property(aresponses, v3_server, v3_settings_response)
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -636,7 +636,7 @@ async def test_set_max_user_pins(aresponses, v3_server, v3_settings_response):
 
         async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
-                simplisafe = await API.login_via_credentials(
+                simplisafe = await get_api(
                     TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
                 )
 
@@ -681,7 +681,7 @@ async def test_set_pin(aresponses, v3_server, v3_settings_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -702,7 +702,7 @@ async def test_set_pin_wrong_chars(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
-                simplisafe = await API.login_via_credentials(
+                simplisafe = await get_api(
                     TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
                 )
 
@@ -719,7 +719,7 @@ async def test_set_pin_wrong_length(v3_server):
     async with v3_server:
         async with aiohttp.ClientSession() as session:
             with pytest.raises(PinError) as err:
-                simplisafe = await API.login_via_credentials(
+                simplisafe = await get_api(
                     TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
                 )
 
@@ -771,7 +771,7 @@ async def test_set_states(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -803,7 +803,7 @@ async def test_system_notifications(aresponses, v3_server, v3_subscriptions_resp
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -837,7 +837,7 @@ async def test_unavailable_endpoint(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -858,7 +858,7 @@ async def test_unknown_initial_state(caplog, v3_server):
     """Test handling of an initially unknown state."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -895,7 +895,7 @@ async def test_update_system_data(
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -906,7 +906,7 @@ async def test_update_system_data(
 
             assert system.serial == TEST_SYSTEM_SERIAL_NO
             assert system.system_id == TEST_SYSTEM_ID
-            assert simplisafe.access_token == TEST_ACCESS_TOKEN
+            assert simplisafe._access_token == TEST_ACCESS_TOKEN
             assert len(system.sensors) == 24
 
 
@@ -938,7 +938,7 @@ async def test_update_error(
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL,
                 TEST_PASSWORD,
                 session=session,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,7 +6,7 @@ import aiohttp
 from aresponses import ResponsesMockServer
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import (
     InvalidCredentialsError,
     PendingAuthorizationError,
@@ -37,7 +37,7 @@ async def test_401_bad_credentials(aresponses):
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.login_via_credentials(
+            await get_api(
                 TEST_EMAIL,
                 TEST_PASSWORD,
                 session=session,
@@ -75,7 +75,7 @@ async def test_401_refresh_token_failure(
 
         async with aiohttp.ClientSession() as session:
             with pytest.raises(InvalidCredentialsError):
-                simplisafe = await API.login_via_credentials(
+                simplisafe = await get_api(
                     TEST_EMAIL,
                     TEST_PASSWORD,
                     session=session,
@@ -134,7 +134,7 @@ async def test_401_refresh_token_success(
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL,
                 TEST_PASSWORD,
                 session=session,
@@ -143,7 +143,7 @@ async def test_401_refresh_token_success(
                 # hang for a long time:
                 request_retry_interval=0,
             )
-            assert simplisafe.client_id == TEST_CLIENT_ID
+            assert simplisafe._client_id == TEST_CLIENT_ID
 
             systems = await simplisafe.get_systems()
             system = systems[TEST_SYSTEM_ID]
@@ -163,7 +163,7 @@ async def test_403_bad_credentials(aresponses):
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.login_via_credentials(
+            await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -180,7 +180,7 @@ async def test_bad_request(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL,
                 TEST_PASSWORD,
                 session=session,
@@ -232,7 +232,7 @@ async def test_expired_token_refresh(aresponses, v2_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -270,6 +270,4 @@ async def test_mfa(aresponses):
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PendingAuthorizationError):
-            await API.login_via_credentials(
-                TEST_EMAIL, TEST_PASSWORD, session=session, client_id=None
-            )
+            await get_api(TEST_EMAIL, TEST_PASSWORD, session=session, client_id=None)

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 
 from .common import (
     TEST_CAMERA_ID,
@@ -28,7 +28,7 @@ async def test_properties(aresponses, v3_server, v3_subscriptions_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -63,7 +63,7 @@ async def test_video_urls(aresponses, v3_server, v3_subscriptions_response):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -2,7 +2,7 @@
 import aiohttp
 import pytest
 
-from simplipy import API
+from simplipy import get_api
 from simplipy.errors import InvalidCredentialsError
 from simplipy.lock import LockStates
 
@@ -41,7 +41,7 @@ async def test_lock_unlock(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -63,7 +63,7 @@ async def test_jammed(v3_server):
     """Test that a jammed lock shows the correct state."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -92,7 +92,7 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -112,7 +112,7 @@ async def test_properties(v3_server):
     """Test that lock properties are created properly."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -135,7 +135,7 @@ async def test_unknown_state(caplog, v3_server):
     """Test handling a generic error during update."""
     async with v3_server:
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 
@@ -186,7 +186,7 @@ async def test_update(aresponses, v3_server):
         )
 
         async with aiohttp.ClientSession() as session:
-            simplisafe = await API.login_via_credentials(
+            simplisafe = await get_api(
                 TEST_EMAIL, TEST_PASSWORD, session=session, client_id=TEST_CLIENT_ID
             )
 


### PR DESCRIPTION
**Describe what the PR does:**

Following up on #240, this PR continues towards handling all refresh token/reauth logic internally by reworking how to retrieve an authenticated API object (via `simplypi.api.get_api`).

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
