### PR TITLE
Fix bug where token refresh and reauth would both erroneously raise an

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -210,12 +210,15 @@ class API:  # pylint: disable=too-many-instance-attributes
                     LOGGER.info("401 detected; attempting refresh token")
                     self._refresh_tried = True
                     await self._refresh_access_token(self._refresh_token)
-                elif not self._reauth_tried:
+                    return await self._single_request(method, endpoint, **kwargs)
+
+                if not self._reauth_tried:
                     LOGGER.info("Another 401 detected; attempting full reauth")
                     self._reauth_tried = True
                     await self.login()
-                else:
-                    raise InvalidCredentialsError("Invalid credentials") from err
+                    return await self._single_request(method, endpoint, **kwargs)
+
+                raise InvalidCredentialsError("Invalid credentials") from err
 
             if "403" in str(err):
                 raise InvalidCredentialsError("Unauthorized") from None


### PR DESCRIPTION
**Describe what the PR does:**

#243 introduced the ability for the `API` object to automatically reauthenticate itself when its refresh token fails, but in both cases, an `InvalidCredentials` exception would still be raised. This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
