### PR TITLE
Protect against null response payloads

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -178,6 +178,10 @@ class API:  # pylint: disable=too-many-instance-attributes
                 message = await resp.text()
                 data = {"error": message}
 
+            if not data:
+                # Some API calls, lock locking/unlocking a lock, won't return anything
+                # at all, in that case, we just return an empty payload:
+                data = {}
             if isinstance(data, str):
                 # In some cases, the SimpliSafe API will return a quoted string
                 # in its response body (e.g., "\"Unauthorized\""), which is

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -178,10 +178,6 @@ class API:  # pylint: disable=too-many-instance-attributes
                 message = await resp.text()
                 data = {"error": message}
 
-            if not data:
-                # Some API calls, lock locking/unlocking a lock, won't return anything
-                # at all, in that case, we just return an empty payload:
-                data = {}
             if isinstance(data, str):
                 # In some cases, the SimpliSafe API will return a quoted string
                 # in its response body (e.g., "\"Unauthorized\""), which is
@@ -195,12 +191,12 @@ class API:  # pylint: disable=too-many-instance-attributes
 
             LOGGER.debug("Data received from /%s: %s", endpoint, data)
 
-            if data.get("error") == "mfa_required":
+            if data and data.get("error") == "mfa_required":
                 # If we get an "error" related to MFA, the response body data is
                 # necessary for continuing on, so we swallow the error and return
                 # that data:
                 return data
-            if data.get("type") == "NoRemoteManagement":
+            if data and data.get("type") == "NoRemoteManagement":
                 raise EndpointUnavailableError(
                     f"Endpoint unavailable in plan: {endpoint}"
                 ) from None

--- a/simplipy/lock.py
+++ b/simplipy/lock.py
@@ -15,9 +15,6 @@ class LockStates(Enum):
     unknown = 99
 
 
-STATE_MAP = {1: LockStates.locked, 2: LockStates.unlocked}
-
-
 class Lock(EntityV3):
     """A lock that works with V3 systems.
 


### PR DESCRIPTION
**Describe what the PR does:**

In certain cases (like with locking/unlocking a lock), the API will return a null payload (with just a successful HTTP response code). This PR protects against unhandled exceptions that might be caused by assuming otherwise.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
