### PR TITLE
Remove official support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - --configfile=.bandit.yaml
         files: ^aiowatttime/.+\.py$
   - repo: https://github.com/python/black
-    rev: 19.10b0
+    rev: 21.7b0
     hooks:
       - id: black
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,16 +8,16 @@ repos:
           - --quiet
           - --format=custom
           - --configfile=.bandit.yaml
-        files: ^(simplipy|scripts)/.+\.py$
+        files: ^aiowatttime/.+\.py$
   - repo: https://github.com/python/black
-    rev: 21.7b0
+    rev: 19.10b0
     hooks:
       - id: black
         args:
           - --safe
           - --quiet
         language_version: python3
-        files: ^((simplipy|scripts|tests)/.+)?[^/]+\.py$
+        files: ^((aiowatttime|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/codespell-project/codespell
     rev: v1.16.0
     hooks:
@@ -25,6 +25,7 @@ repos:
         args:
           - --skip="./.*,*.json"
           - --quiet-level=4
+          - -L ba
         exclude_types: [json]
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
@@ -33,19 +34,19 @@ repos:
         additional_dependencies:
           - flake8-docstrings==1.5.0
           - pydocstyle==5.0.1
-        files: ^(simplipy|scripts)/.+\.py$
+        files: ^aiowatttime/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:
       - id: isort
         additional_dependencies:
           - toml
-        files: ^(simplipy|scripts|tests)/.+\.py$
+        files: ^(aiowatttime|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.910
     hooks:
       - id: mypy
-        files: ^(simplipy|scripts)/.+\.py$
+        files: ^aiowatttime/.+\.py$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.4.0
     hooks:
@@ -58,7 +59,7 @@ repos:
     rev: 5.0.2
     hooks:
       - id: pydocstyle
-        files: ^((aioambient|tests)/.+)?[^/]+\.py$
+        files: ^((aiowatttime|tests)/.+)?[^/]+\.py$
   - repo: https://github.com/gruntwork-io/pre-commit
     rev: v0.1.12
     hooks:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -14,7 +14,6 @@ Python Versions
 
 ``simplisafe-python`` is currently supported on:
 
-* Python 3.7
 * Python 3.8
 * Python 3.9
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: Implementation :: CPython",
@@ -62,7 +61,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4.post0"
 backoff = "^1.11.1"
-python = "^3.7.0"
+python = "^3.8.0"
 pytz = ">=2019.3,<2022.0"
 types-pytz = "^2021.1.0"
 voluptuous = ">=0.11.7,<0.13.0"

--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -1,6 +1,8 @@
 """Define a base SimpliSafe device."""
+from __future__ import annotations
+
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Dict, cast
+from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
     from simplipy.system import System
@@ -43,7 +45,7 @@ class Device:
     :type serial: ``str``
     """
 
-    def __init__(self, system: "System", device_type: DeviceTypes, serial: str) -> None:
+    def __init__(self, system: System, device_type: DeviceTypes, serial: str) -> None:
         """Initialize."""
         self._device_type = device_type
         self._serial = serial
@@ -122,11 +124,11 @@ class DeviceV3(Device):
         return cast(bool, self._system.sensor_data[self._serial]["flags"]["offline"])
 
     @property
-    def settings(self) -> Dict[str, Any]:
+    def settings(self) -> dict[str, Any]:
         """Return the device's settings.
 
         Note that these can change based on what device type the device is.
 
         :rtype: ``dict``
         """
-        return cast(Dict[str, Any], self._system.sensor_data[self._serial]["setting"])
+        return cast(dict[str, Any], self._system.sensor_data[self._serial]["setting"])

--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Dict, cast
 
 if TYPE_CHECKING:
     from simplipy.system import System
@@ -131,4 +131,4 @@ class DeviceV3(Device):
 
         :rtype: ``dict``
         """
-        return cast(dict[str, Any], self._system.sensor_data[self._serial]["setting"])
+        return cast(Dict[str, Any], self._system.sensor_data[self._serial]["setting"])

--- a/simplipy/device/camera.py
+++ b/simplipy/device/camera.py
@@ -1,7 +1,7 @@
 """Define SimpliSafe cameras (SimpliCams)."""
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, Dict, cast
 from urllib.parse import urlencode
 
 from simplipy.const import LOGGER
@@ -39,7 +39,7 @@ class Camera(DeviceV3):
         :rtype: ``dict``
         """
         return cast(
-            dict[str, Any], self._system.camera_data[self._serial]["cameraSettings"]
+            Dict[str, Any], self._system.camera_data[self._serial]["cameraSettings"]
         )
 
     @property

--- a/simplipy/device/camera.py
+++ b/simplipy/device/camera.py
@@ -1,5 +1,7 @@
 """Define SimpliSafe cameras (SimpliCams)."""
-from typing import TYPE_CHECKING, Any, Dict, cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import urlencode
 
 from simplipy.const import LOGGER
@@ -28,16 +30,16 @@ MODEL_TO_TYPE = {
 class Camera(DeviceV3):
     """Define a SimpliCam."""
 
-    _system: "SystemV3"
+    _system: SystemV3
 
     @property
-    def camera_settings(self) -> Dict[str, Any]:
+    def camera_settings(self) -> dict[str, Any]:
         """Return the camera settings.
 
         :rtype: ``dict``
         """
         return cast(
-            Dict[str, Any], self._system.camera_data[self._serial]["cameraSettings"]
+            dict[str, Any], self._system.camera_data[self._serial]["cameraSettings"]
         )
 
     @property
@@ -122,7 +124,7 @@ class Camera(DeviceV3):
         self,
         width: int = DEFAULT_VIDEO_WIDTH,
         audio_encoding: str = DEFAULT_AUDIO_ENCODING,
-        **kwargs: Dict[str, Any],
+        **kwargs: dict[str, Any],
     ) -> str:
         """Return the camera video URL.
 

--- a/simplipy/device/sensor/__init__.py
+++ b/simplipy/device/sensor/__init__.py
@@ -1,0 +1,1 @@
+"""Define sensors."""

--- a/simplipy/device/sensor/v3.py
+++ b/simplipy/device/sensor/v3.py
@@ -1,5 +1,5 @@
 """Define a v3 (new) SimpliSafe sensor."""
-from typing import Optional, cast
+from typing import cast
 
 from simplipy.device import DeviceTypes, DeviceV3
 
@@ -49,7 +49,7 @@ class SensorV3(DeviceV3):
         return False
 
     @property
-    def temperature(self) -> Optional[int]:
+    def temperature(self) -> int:
         """Return the temperature of the sensor (as appropriate).
 
         If the sensor isn't a temperature sensor, an ``AttributeError`` will be raised.

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -5,7 +5,7 @@ import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, cast
 
 from simplipy.const import LOGGER
 from simplipy.device import DeviceTypes
@@ -282,7 +282,7 @@ class System:
             "get", f"subscriptions/{self.system_id}/events", params=params
         )
 
-        return cast(list[dict[str, Any]], events_resp.get("events", []))
+        return cast(List[Dict[str, Any]], events_resp.get("events", []))
 
     async def get_latest_event(self) -> dict:
         """Get the most recent system event.

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -1,9 +1,11 @@
 """Define V2 and V3 SimpliSafe systems."""
+from __future__ import annotations
+
 import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from simplipy.const import LOGGER
 from simplipy.device import DeviceTypes
@@ -40,8 +42,8 @@ class SystemNotification:
     code: str
     timestamp: float
 
-    link: Optional[str] = None
-    link_label: Optional[str] = None
+    link: str | None = None
+    link_label: str | None = None
 
     def __post_init__(self) -> None:
         """Run post-init initialization."""
@@ -74,7 +76,7 @@ def coerce_state_from_raw_value(value: str) -> SystemStates:
         return SystemStates.unknown
 
 
-def get_device_type_from_data(device_data: Dict[str, Any]) -> DeviceTypes:
+def get_device_type_from_data(device_data: dict[str, Any]) -> DeviceTypes:
     """Get the device type of a raw data payload."""
     try:
         return DeviceTypes(device_data["type"])
@@ -122,10 +124,10 @@ class System:
         self._sid = sid
 
         # These will get filled in after initial update:
-        self._notifications: List[SystemNotification] = []
+        self._notifications: list[SystemNotification] = []
         self._state = SystemStates.unknown
-        self.sensor_data: Dict[str, Dict[str, Any]] = {}
-        self.sensors: Dict[str, Union[SensorV2, SensorV3]] = {}
+        self.sensor_data: dict[str, dict[str, Any]] = {}
+        self.sensors: dict[str, SensorV2 | SensorV3] = {}
 
     @property  # type: ignore
     @guard_from_missing_data()
@@ -161,7 +163,7 @@ class System:
         )
 
     @property
-    def notifications(self) -> List[SystemNotification]:
+    def notifications(self) -> list[SystemNotification]:
         """Return the system's current messages/notifications.
 
         :rtype: ``List[:meth:`simplipy.system.SystemNotification`]``
@@ -225,7 +227,7 @@ class System:
         """Raise if calling this undefined based method."""
         raise NotImplementedError()
 
-    async def _set_updated_pins(self, pins: Dict[str, Any]) -> None:
+    async def _set_updated_pins(self, pins: dict[str, Any]) -> None:
         """Post new PINs."""
         raise NotImplementedError()
 
@@ -258,8 +260,8 @@ class System:
         raise NotImplementedError()
 
     async def get_events(
-        self, from_datetime: Optional[datetime] = None, num_events: Optional[int] = None
-    ) -> List[Dict[str, Any]]:
+        self, from_datetime: datetime | None = None, num_events: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get events recorded by the base station.
 
         If no parameters are provided, this will return the most recent 50 events.
@@ -280,7 +282,7 @@ class System:
             "get", f"subscriptions/{self.system_id}/events", params=params
         )
 
-        return cast(List[Dict[str, Any]], events_resp.get("events", []))
+        return cast(list[dict[str, Any]], events_resp.get("events", []))
 
     async def get_latest_event(self) -> dict:
         """Get the most recent system event.
@@ -294,7 +296,7 @@ class System:
         except IndexError:
             raise SimplipyError("SimpliSafe didn't return any events") from None
 
-    async def get_pins(self, cached: bool = True) -> Dict[str, str]:
+    async def get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -1,5 +1,5 @@
 """Define a V2 (original) SimpliSafe system."""
-from typing import Dict
+from __future__ import annotations
 
 from simplipy.const import LOGGER
 from simplipy.device.sensor.v2 import SensorV2
@@ -14,7 +14,7 @@ from simplipy.system import (
 )
 
 
-def create_pin_payload(pins: dict) -> Dict[str, Dict[str, Dict[str, str]]]:
+def create_pin_payload(pins: dict) -> dict[str, dict[str, dict[str, str]]]:
     """Create the request payload to send for updating PINs."""
     duress_pin = pins.pop(CONF_DURESS_PIN)
     master_pin = pins.pop(CONF_MASTER_PIN)
@@ -83,7 +83,7 @@ class SystemV2(System):
             sensor_type = get_device_type_from_data(data)
             self.sensors[serial] = SensorV2(self, sensor_type, serial)
 
-    async def get_pins(self, cached: bool = True) -> Dict[str, str]:
+    async def get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last
@@ -91,7 +91,7 @@ class SystemV2(System):
 
         :param cached: Whether to used cached data.
         :type cached: ``bool``
-        :rtype: ``Dict[str, str]``
+        :rtype: ``dict[str, str]``
         """
         pins_resp = await self._api.request(
             "get",

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -1,6 +1,8 @@
 """Define a V3 (new) SimpliSafe system."""
+from __future__ import annotations
+
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Dict, Optional, cast
+from typing import TYPE_CHECKING, cast
 
 import voluptuous as vol
 
@@ -80,7 +82,7 @@ SYSTEM_PROPERTIES_PAYLOAD_SCHEMA = vol.Schema(
 )
 
 
-def create_pin_payload(pins: dict) -> Dict[str, Dict[str, Dict[str, str]]]:
+def create_pin_payload(pins: dict) -> dict[str, dict[str, dict[str, str]]]:
     """Create the request payload to send for updating PINs."""
     duress_pin = pins.pop(CONF_DURESS_PIN)
     master_pin = pins.pop(CONF_MASTER_PIN)
@@ -117,13 +119,13 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         """Initialize."""
         super().__init__(api, system_id)
 
-        self._last_state_change_dt: Optional[datetime] = None
+        self._last_state_change_dt: datetime | None = None
 
         # This will be filled in by the appropriate data update methods:
-        self.camera_data: Dict[str, dict] = self._generate_camera_data()
-        self.cameras: Dict[str, Camera] = {}
-        self.locks: Dict[str, Lock] = {}
-        self.settings_data: Dict[str, dict] = {}
+        self.camera_data: dict[str, dict] = self._generate_camera_data()
+        self.cameras: dict[str, Camera] = {}
+        self.locks: dict[str, Lock] = {}
+        self.settings_data: dict[str, dict] = {}
 
     @property  # type: ignore
     @guard_from_missing_data()
@@ -327,7 +329,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         """
         return cast(int, self.settings_data["basestationStatus"]["wifiRssi"])
 
-    def _generate_camera_data(self) -> Dict[str, dict]:
+    def _generate_camera_data(self) -> dict[str, dict]:
         """Generate usable, hashable camera data from subscription data.
 
         This method exists because the SimpliSafe API includes camera data with the
@@ -397,7 +399,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         for serial in self.camera_data:
             self.cameras[serial] = Camera(self, DeviceTypes.camera, serial)
 
-    async def get_pins(self, cached: bool = True) -> Dict[str, str]:
+    async def get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last
@@ -405,7 +407,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
         :param cached: Whether to used cached data.
         :type cached: ``bool``
-        :rtype: ``Dict[str, str]``
+        :rtype: ``dict[str, str]``
         """
         await self._update_settings_data(cached)
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR removes official support for Python 3.7. Since my primary goal is supporting Home Assistant and they maintain compatibility with the two most recent Python versions, I aim to do the same.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
