### PR TITLE
Add `async_` prefix to all coroutine definitions

### DIFF
--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -69,8 +69,8 @@ Locking and unlocking a lock is accomplished via two coroutines:
 .. code:: python
 
     for serial, lock in system.locks.items():
-        await lock.lock()
-        await lock.unlock()
+        await lock.async_lock()
+        await lock.async_unlock()
 
 
 Updating the Lock
@@ -80,4 +80,4 @@ To retrieve the sensor's latest state/properties/etc., simply:
 
 .. code:: python
 
-    await lock.update(cached=True)
+    await lock.async_update(cached=True)

--- a/docs/sensor.rst
+++ b/docs/sensor.rst
@@ -92,4 +92,4 @@ To retrieve the sensor's latest state/properties/etc., simply:
 
 .. code:: python
 
-    await sensor.update(cached=True)
+    await sensor.async_update(cached=True)

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -26,14 +26,14 @@ To get all SimpliSafe™ systems associated with an account:
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await simplipy.API.from_auth(
+            simplisafe = await simplipy.API.async_from_auth(
                 "<AUTHORIZATION_CODE>",
                 "<CODE_VERIFIER>",
                 session=session,
             )
 
             # Get a dict of systems with the system ID as the key:
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             # >>> {"1234abc": <simplipy.system.SystemV2 object>, ...}
 
 
@@ -176,7 +176,7 @@ automatically come with additional properties:
     system.wifi_strength
     # >>> -43
 
-V3 systems also come with a :meth:`set_properties <simplipy.system.v3.SystemV3.set_properties>`
+V3 systems also come with a :meth:`async_set_properties <simplipy.system.v3.SystemV3.async_set_properties>`
 method to update the following system properties:
 
 * ``alarm_duration`` (in seconds): 30-480
@@ -196,7 +196,7 @@ Note that volume properties can accept integers or constants defined in
 
     from simplipy.system.v3 import VOLUME_OFF, VOLUME_LOW, VOLUME_MEDIUM
 
-    await system.set_properties(
+    await system.async_set_properties(
         {
             "alarm_duration": 240,
             "alarm_volume": VOLUME_HIGH,
@@ -228,7 +228,7 @@ Refreshing the :meth:`System <simplipy.system.System>` object is done via the
 
 .. code:: python
 
-    await system.update()
+    await system.async_update()
 
 Note that this method can be supplied with four optional parameters (all of which
 default to ``True``):
@@ -243,7 +243,7 @@ refresh:
 
 .. code:: python
 
-    await system.update(include_system=False, include_settings=False, cached=False)
+    await system.async_update(include_system=False, include_settings=False, cached=False)
 
 There are two crucial differences between V2 and V3 systems when updating:
 
@@ -261,9 +261,9 @@ of three coroutines:
 
 .. code:: python
 
-    await system.set_away()
-    await system.set_home()
-    await system.set_off()
+    await system.async_set_away()
+    await system.async_set_home()
+    await system.async_set_off()
 
 
 Events
@@ -277,12 +277,12 @@ occurred with their system:
    from datetime import datetime, timedelta
 
    yesterday = datetime.now() - timedelta(days=1)
-    await system.get_events(
+    await system.async_get_events(
         from_timestamp=yesterday, num_events=2
     )
     # >>> [{"eventId": 123, ...}, {"eventId": 456, ...}]
 
-    await system.get_latest_event()
+    await system.async_get_latest_event()
     # >>> {"eventId": 987, ...}
 
 System Notifications
@@ -308,22 +308,22 @@ associated with a SimpliSafe™ account:
 .. code:: python
 
     # Get all PINs (retrieving fresh or from the cache):
-    await system.get_pins(cached=False)
+    await system.async_get_pins(cached=False)
     # >>> {"master": "1234", "duress": "9876"}
 
     # Set a new user PIN:
-    await system.set_pin("My New User", "1122")
-    await system.get_pins(cached=False)
+    await system.async_set_pin("My New User", "1122")
+    await system.async_get_pins(cached=False)
     # >>> {"master": "1234", "duress": "9876", "My New User": "1122"}
 
     # Remove a PIN (by value or by label)
-    await system.remove_pin("My New User")
-    await system.get_pins(cached=False)
+    await system.async_remove_pin("My New User")
+    await system.async_get_pins(cached=False)
     # >>> {"master": "1234", "duress": "9876"}
 
     # Set the master PIN (works for the duress PIN, too):
-    await system.set_pin("master", "9865")
-    await system.get_pins(cached=False)
+    await system.async_set_pin("master", "9865")
+    await system.async_get_pins(cached=False)
     # >>> {"master": "9865", "duress": "9876"}
 
 Remember that with V2 systems, many operations – including setting PINs – will cause

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -131,7 +131,7 @@ this:
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await simplipy.API.from_auth(
+            simplisafe = await simplipy.API.async_from_auth(
                 "<AUTHORIZATION_CODE>",
                 "<CODE_VERIFIER>",
                 session=session,
@@ -162,14 +162,14 @@ access token:
     async def main() -> None:
         """Create the aiohttp session and run."""
         async with ClientSession() as session:
-            simplisafe = await simplipy.API.from_auth(
+            simplisafe = await simplipy.API.async_from_auth(
                 "<AUTHORIZATION_CODE>",
                 "<CODE_VERIFIER>",
                 session=session,
             )
 
             # Sometime later:
-            new_simplisafe = await simplipy.API.from_refresh_token(
+            new_simplisafe = await simplipy.API.async_from_refresh_token(
                 simplisafe.refresh_token,
                 session=session,
             )

--- a/examples/test_client_by_auth.py
+++ b/examples/test_client_by_auth.py
@@ -19,12 +19,12 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 SIMPLISAFE_AUTHORIZATION_CODE,
                 SIMPLISAFE_CODE_VERIFIER,
                 session=session,
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             for system in systems.values():
                 # Print system state:
                 _LOGGER.info("System state: %s", system.state)
@@ -40,26 +40,26 @@ async def main() -> None:
                     )
 
                 # Arm/disarm the system:
-                # await system.set_away()
-                # await system.set_home()
-                # await system.set_off()
+                # await system.async_set_away()
+                # await system.async_set_home()
+                # await system.async_set_off()
 
                 # Print system events:
-                events = await system.get_events()
+                events = await system.async_get_events()
                 for event in events:
                     _LOGGER.info("Event: %s", event)
 
                 # Set PINs:
-                # await system.set_pin("Test PIN", "1235")
-                # await system.remove_pin("Test PIN")
+                # await system.async_set_pin("Test PIN", "1235")
+                # await system.async_remove_pin("Test PIN")
 
                 # Interact with locks (if we have them):
                 for serial, lock in system.locks.items():
                     _LOGGER.info(
                         "Lock %s: (name: %s, state: %s)", serial, lock.name, lock.state
                     )
-                    # await lock.lock()
-                    # await lock.unlock()
+                    # await lock.async_lock()
+                    # await lock.async_unlock()
         except SimplipyError as err:
             _LOGGER.error(err)
 

--- a/examples/test_client_by_refresh_token.py
+++ b/examples/test_client_by_refresh_token.py
@@ -18,10 +18,10 @@ async def main() -> None:
         logging.basicConfig(level=logging.INFO)
 
         try:
-            simplisafe = await API.from_refresh_token(
+            simplisafe = await API.async_from_refresh_token(
                 SIMPLISAFE_REFRESH_TOKEN, session=session
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             for system in systems.values():
                 # Print system state:
                 _LOGGER.info("System state: %s", system.state)
@@ -37,26 +37,26 @@ async def main() -> None:
                     )
 
                 # Arm/disarm the system:
-                # await system.set_away()
-                # await system.set_home()
-                # await system.set_off()
+                # await system.async_set_away()
+                # await system.async_set_home()
+                # await system.async_set_off()
 
                 # Print system events:
-                events = await system.get_events()
+                events = await system.async_get_events()
                 for event in events:
                     _LOGGER.info("Event: %s", event)
 
                 # Set PINs:
-                # await system.set_pin("Test PIN", "1235")
-                # await system.remove_pin("Test PIN")
+                # await system.async_set_pin("Test PIN", "1235")
+                # await system.async_remove_pin("Test PIN")
 
                 # Interact with locks (if we have them):
                 for serial, lock in system.locks.items():
                     _LOGGER.info(
                         "Lock %s: (name: %s, state: %s)", serial, lock.name, lock.state
                     )
-                    # await lock.lock()
-                    # await lock.unlock()
+                    # await lock.async_lock()
+                    # await lock.async_unlock()
         except SimplipyError as err:
             _LOGGER.error(err)
 

--- a/examples/test_websocket.py
+++ b/examples/test_websocket.py
@@ -18,7 +18,7 @@ async def main() -> None:
         logging.basicConfig(level=logging.DEBUG)
 
         try:
-            simplisafe = await API.from_refresh_token(
+            simplisafe = await API.async_from_refresh_token(
                 SIMPLISAFE_REFRESH_TOKEN, session=session
             )
 

--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -35,7 +35,7 @@ class Device:
     """A base SimpliSafe device.
 
     Note that this class shouldn't be instantiated directly; it will be instantiated as
-    appropriate via :meth:`simplipy.API.get_systems`.
+    appropriate via :meth:`simplipy.API.async_get_systems`.
 
     :param system: A :meth:`simplipy.system.System` object (or one of its subclasses)
     :type system: :meth:`simplipy.system.System`
@@ -75,7 +75,7 @@ class Device:
         """
         return self._device_type
 
-    async def update(self, cached: bool = True) -> None:
+    async def async_update(self, cached: bool = True) -> None:
         """Retrieve the latest state/properties for the device.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last
@@ -84,7 +84,7 @@ class Device:
         :param cached: Whether to used cached data.
         :type cached: ``bool``
         """
-        await self._system.update(
+        await self._system.async_update(
             include_subscription=False, include_settings=False, cached=cached
         )
 
@@ -93,7 +93,7 @@ class DeviceV3(Device):
     """A base device for V3 systems.
 
     Note that this class shouldn't be instantiated directly; it will be
-    instantiated as appropriate via :meth:`simplipy.API.get_systems`.
+    instantiated as appropriate via :meth:`simplipy.API.async_get_systems`.
     """
 
     @property

--- a/simplipy/device/lock.py
+++ b/simplipy/device/lock.py
@@ -22,7 +22,7 @@ class Lock(DeviceV3):
     """A lock that works with V3 systems.
 
     Note that this class shouldn't be instantiated directly; it will be
-    instantiated as appropriate via :meth:`simplipy.API.get_systems`.
+    instantiated as appropriate via :meth:`simplipy.API.async_get_systems`.
 
     :param api: A :meth:`simplipy.API` object
     :type api: :meth:`simplipy.API`
@@ -113,7 +113,7 @@ class Lock(DeviceV3):
             return LockStates.locked
         return LockStates.unlocked
 
-    async def lock(self) -> None:
+    async def async_lock(self) -> None:
         """Lock the lock."""
         await self._request(
             "post",
@@ -126,7 +126,7 @@ class Lock(DeviceV3):
             "lockState"
         ] = self._InternalStates.locked.value
 
-    async def unlock(self) -> None:
+    async def async_unlock(self) -> None:
         """Unlock the lock."""
         await self._request(
             "post",

--- a/simplipy/device/sensor/v2.py
+++ b/simplipy/device/sensor/v2.py
@@ -9,7 +9,7 @@ class SensorV2(Device):
     """A V2 (old) sensor.
 
     Note that this class shouldn't be instantiated directly; it will be
-    instantiated as appropriate via :meth:`simplipy.API.get_systems`.
+    instantiated as appropriate via :meth:`simplipy.API.async_get_systems`.
     """
 
     @property

--- a/simplipy/device/sensor/v3.py
+++ b/simplipy/device/sensor/v3.py
@@ -8,7 +8,7 @@ class SensorV3(DeviceV3):
     """A V3 (new) sensor.
 
     Note that this class shouldn't be instantiated directly; it will be
-    instantiated as appropriate via :meth:`simplipy.API.get_systems`.
+    instantiated as appropriate via :meth:`simplipy.API.async_get_systems`.
     """
 
     @property

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -41,7 +41,7 @@ def create_pin_payload(pins: dict) -> dict[str, dict[str, dict[str, str]]]:
 class SystemV2(System):
     """Define a V2 (original) system."""
 
-    async def _set_state(self, value: SystemStates) -> None:
+    async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
         state_resp = await self._api.request(
             "post",
@@ -52,7 +52,7 @@ class SystemV2(System):
         if state_resp["success"]:
             self._state = coerce_state_from_raw_value(state_resp["requestedState"])
 
-    async def _set_updated_pins(self, pins: dict) -> None:
+    async def _async_set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""
         await self._api.request(
             "post",
@@ -60,7 +60,7 @@ class SystemV2(System):
             json=create_pin_payload(pins),
         )
 
-    async def _update_device_data(self, cached: bool = True) -> None:
+    async def _async_update_device_data(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""
         sensor_resp = await self._api.request(
             "get",
@@ -73,7 +73,7 @@ class SystemV2(System):
                 continue
             self.sensor_data[sensor["serial"]] = sensor
 
-    async def _update_settings_data(self, cached: bool = True) -> None:
+    async def _async_update_settings_data(self, cached: bool = True) -> None:
         """Update all settings data."""
         pass
 
@@ -83,7 +83,7 @@ class SystemV2(System):
             sensor_type = get_device_type_from_data(data)
             self.sensors[serial] = SensorV2(self, sensor_type, serial)
 
-    async def get_pins(self, cached: bool = True) -> dict[str, str]:
+    async def async_get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -343,7 +343,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
             ].get("cameras", [])
         }
 
-    async def _set_state(self, value: SystemStates) -> None:
+    async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
         state_resp = await self._api.request(
             "post", f"ss3/subscriptions/{self.system_id}/state/{value.name}"
@@ -352,7 +352,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         self._state = coerce_state_from_raw_value(state_resp["state"])
         self._last_state_change_dt = datetime.utcnow()
 
-    async def _set_updated_pins(self, pins: dict) -> None:
+    async def _async_set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""
         self.settings_data = await self._api.request(
             "post",
@@ -360,7 +360,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
             json=create_pin_payload(pins),
         )
 
-    async def _update_device_data(self, cached: bool = True) -> None:
+    async def _async_update_device_data(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""
         sensor_resp = await self._api.request(
             "get",
@@ -371,7 +371,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
             sensor["serial"]: sensor for sensor in sensor_resp.get("sensors", [])
         }
 
-    async def _update_settings_data(self, cached: bool = True) -> None:
+    async def _async_update_settings_data(self, cached: bool = True) -> None:
         """Get all system settings."""
         settings_resp = await self._api.request(
             "get",
@@ -382,9 +382,9 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         if settings_resp:
             self.settings_data = settings_resp
 
-    async def _update_subscription_data(self) -> None:
+    async def _async_update_subscription_data(self) -> None:
         """Update subscription data."""
-        await super()._update_subscription_data()
+        await super()._async_update_subscription_data()
         self.camera_data = self._generate_camera_data()
 
     def generate_device_objects(self) -> None:
@@ -399,7 +399,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         for serial in self.camera_data:
             self.cameras[serial] = Camera(self, DeviceTypes.camera, serial)
 
-    async def get_pins(self, cached: bool = True) -> dict[str, str]:
+    async def async_get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 
         The ``cached`` parameter determines whether the SimpliSafe Cloud uses the last
@@ -409,7 +409,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         :type cached: ``bool``
         :rtype: ``dict[str, str]``
         """
-        await self._update_settings_data(cached)
+        await self._async_update_settings_data(cached)
 
         pins = {
             CONF_MASTER_PIN: self.settings_data["settings"]["pins"]["master"]["pin"],
@@ -423,7 +423,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
         return pins
 
-    async def set_properties(self, properties: dict) -> None:
+    async def async_set_properties(self, properties: dict) -> None:
         """Set various system properties.
 
         The following properties can be set:
@@ -461,7 +461,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         if settings_resp:
             self.settings_data = settings_resp
 
-    async def update(
+    async def async_update(
         self,
         *,
         include_subscription: bool = True,
@@ -499,7 +499,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
             )
             return
 
-        await super().update(
+        await super().async_update(
             include_subscription=include_subscription,
             include_settings=include_settings,
             include_devices=include_devices,

--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -203,8 +203,8 @@ class WebsocketClient:
     """A websocket connection to the SimpliSafe cloud.
 
     Note that this class shouldn't be instantiated directly; it will be instantiated as
-    appropriate via :meth:`simplipy.API.from_auth` or
-    :meth:`simplipy.API.from_refresh_token`.
+    appropriate via :meth:`simplipy.API.async_from_auth` or
+    :meth:`simplipy.API.async_from_refresh_token`.
 
     :param api: A :meth:`simplipy.API` object
     :type api: :meth:`simplipy.API`

--- a/tests/sensor/test_base.py
+++ b/tests/sensor/test_base.py
@@ -13,10 +13,10 @@ from tests.common import TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, TEST_SYSTE
 async def test_properties_base(aresponses, v2_server):
     """Test that base sensor properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         sensor = system.sensors["195"]
         assert sensor.name == "Garage Keypad"

--- a/tests/sensor/test_v2.py
+++ b/tests/sensor/test_v2.py
@@ -13,10 +13,10 @@ from tests.common import TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, TEST_SYSTE
 async def test_properties_v2(aresponses, v2_server):
     """Test that v2 sensor properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         keypad = system.sensors["195"]
         assert keypad.data == 0

--- a/tests/sensor/test_v3.py
+++ b/tests/sensor/test_v3.py
@@ -12,10 +12,10 @@ from tests.common import TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, TEST_SYSTE
 async def test_properties_v3(aresponses, v3_server):
     """Test that v3 sensor properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         entry_sensor = system.sensors["825"]

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -21,7 +21,7 @@ from tests.common import (
 
 @pytest.mark.asyncio
 async def test_deactivated_system(aresponses, server, subscriptions_response):
-    """Test that API.get_systems doesn't return deactivated systems."""
+    """Test that API.async_get_systems doesn't return deactivated systems."""
     subscriptions_response["subscriptions"][0]["activated"] = 0
 
     server.add(
@@ -32,10 +32,10 @@ async def test_deactivated_system(aresponses, server, subscriptions_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         assert len(systems) == 0
 
     aresponses.assert_plan_strictly_followed()
@@ -52,12 +52,12 @@ async def test_get_events(aresponses, events_response, v2_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        events = await system.get_events(datetime.now(), 2)
+        events = await system.async_get_events(datetime.now(), 2)
         assert len(events) == 2
 
     aresponses.assert_plan_strictly_followed()
@@ -95,10 +95,10 @@ async def test_missing_property(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.offline is True
         assert any(
@@ -122,10 +122,10 @@ async def test_missing_system_info(aresponses, caplog, server, subscriptions_res
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
         assert any(
             "Skipping subscription with missing system data" in e.message
             for e in caplog.records
@@ -138,10 +138,10 @@ async def test_missing_system_info(aresponses, caplog, server, subscriptions_res
 async def test_properties(aresponses, v2_server):
     """Test that base system properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert not system.alarm_going_off
         assert system.address == TEST_ADDRESS
@@ -159,10 +159,10 @@ async def test_properties(aresponses, v2_server):
 async def test_unknown_sensor_type(aresponses, caplog, v2_server):
     """Test whether a message is logged upon finding an unknown sensor type."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
         assert any("Unknown device type" in e.message for e in caplog.records)
 
     aresponses.assert_plan_strictly_followed()
@@ -202,10 +202,10 @@ async def test_unknown_system_state(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
         assert any("Unknown raw system state" in e.message for e in caplog.records)
         assert any("NOT_REAL_STATE" in e.message for e in caplog.records)
 

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -26,12 +26,12 @@ async def test_get_pins(aresponses, v2_pins_response, v2_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        pins = await system.get_pins()
+        pins = await system.async_get_pins()
 
         assert len(pins) == 4
         assert pins["master"] == "1234"
@@ -43,13 +43,13 @@ async def test_get_pins(aresponses, v2_pins_response, v2_server):
 
 
 @pytest.mark.asyncio
-async def test_get_systems(aresponses, v2_server, v2_subscriptions_response):
+async def test_async_get_systems(aresponses, v2_server, v2_subscriptions_response):
     """Test the ability to get systems attached to a v2 account."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         assert len(systems) == 1
 
         system = systems[TEST_SYSTEM_ID]
@@ -93,17 +93,17 @@ async def test_set_pin(aresponses, v2_pins_response, v2_server, v2_settings_resp
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        latest_pins = await system.get_pins()
+        latest_pins = await system.async_get_pins()
         assert len(latest_pins) == 4
 
-        await system.set_pin("whatever", "1275")
-        new_pins = await system.get_pins()
+        await system.async_set_pin("whatever", "1275")
+        new_pins = await system.async_get_pins()
         assert len(new_pins) == 5
 
     aresponses.assert_plan_strictly_followed()
@@ -140,19 +140,19 @@ async def test_set_states(aresponses, v2_server, v2_state_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        await system.set_away()
+        await system.async_set_away()
         assert system.state == SystemStates.away
 
-        await system.set_home()
+        await system.async_set_home()
         assert system.state == SystemStates.home
 
-        await system.set_off()
+        await system.async_set_off()
         assert system.state == SystemStates.off
 
     aresponses.assert_plan_strictly_followed()
@@ -179,16 +179,16 @@ async def test_update_system_data(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.serial == TEST_SYSTEM_SERIAL_NO
         assert system.system_id == TEST_SYSTEM_ID
         assert len(system.sensors) == 35
 
         # If this succeeds without throwing an exception, the update is successful:
-        await system.update()
+        await system.async_update()
 
     aresponses.assert_plan_strictly_followed()

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -32,10 +32,10 @@ from tests.common import (
 async def test_alarm_state(aresponses, v3_server):
     """Test that we can get the alarm state."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.state == SystemStates.off
 
@@ -53,12 +53,12 @@ async def test_clear_notifications(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        await system.clear_notifications()
+        await system.async_clear_notifications()
         assert system.notifications == []
 
     aresponses.assert_plan_strictly_followed()
@@ -75,12 +75,12 @@ async def test_get_last_event(aresponses, latest_event_response, v3_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        latest_event = await system.get_latest_event()
+        latest_event = await system.async_get_latest_event()
         assert latest_event["eventId"] == 1234567890
 
     aresponses.assert_plan_strictly_followed()
@@ -97,12 +97,12 @@ async def test_get_pins(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        pins = await system.get_pins()
+        pins = await system.async_get_pins()
         assert len(pins) == 4
         assert pins["master"] == "1234"
         assert pins["duress"] == "9876"
@@ -113,13 +113,13 @@ async def test_get_pins(aresponses, v3_server, v3_settings_response):
 
 
 @pytest.mark.asyncio
-async def test_get_systems(aresponses, v3_server):
+async def test_async_get_systems(aresponses, v3_server):
     """Test the ability to get systems attached to a v3 account."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         assert len(systems) == 1
 
         system = systems[TEST_SYSTEM_ID]
@@ -143,15 +143,15 @@ async def test_empty_events(aresponses, events_response, v3_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         # Test the events key existing, but being empty:
         with pytest.raises(SimplipyError):
-            _ = await system.get_latest_event()
+            _ = await system.async_get_latest_event()
 
     aresponses.assert_plan_strictly_followed()
 
@@ -171,16 +171,16 @@ async def test_lock_state_update_bug(aresponses, caplog, v3_server, v3_state_res
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        await system.set_away()
+        await system.async_set_away()
         assert system.state == SystemStates.away
 
-        await system.update()
+        await system.async_update()
         assert any("Skipping system update" in e.message for e in caplog.records)
 
     aresponses.assert_plan_strictly_followed()
@@ -199,15 +199,15 @@ async def test_missing_events(aresponses, events_response, v3_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         # Test the events key existing, but being empty:
         with pytest.raises(SimplipyError):
-            _ = await system.get_latest_event()
+            _ = await system.async_get_latest_event()
 
     aresponses.assert_plan_strictly_followed()
 
@@ -229,15 +229,15 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.state == SystemStates.off
 
         with pytest.raises(InvalidCredentialsError):
-            await system.set_away()
+            await system.async_set_away()
         assert system.state == SystemStates.off
 
     aresponses.assert_plan_strictly_followed()
@@ -254,10 +254,10 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.alarm_duration == 240
         assert system.alarm_volume == VOLUME_HIGH
@@ -290,7 +290,7 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         system.settings_data["settings"]["normal"]["light"] = False
         system.settings_data["settings"]["normal"]["voicePrompts"] = 0
 
-        await system.set_properties(
+        await system.async_set_properties(
             {
                 "alarm_duration": 240,
                 "alarm_volume": VOLUME_HIGH,
@@ -327,14 +327,14 @@ async def test_remove_nonexistent_pin(aresponses, v3_server, v3_settings_respons
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         with pytest.raises(PinError) as err:
-            await system.remove_pin("0000")
+            await system.async_remove_pin("0000")
             assert "Refusing to delete nonexistent PIN" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -373,16 +373,16 @@ async def test_remove_pin(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        latest_pins = await system.get_pins()
+        latest_pins = await system.async_get_pins()
         assert len(latest_pins) == 4
 
-        await system.remove_pin("Test 2")
-        latest_pins = await system.get_pins()
+        await system.async_remove_pin("Test 2")
+        latest_pins = await system.async_get_pins()
         assert len(latest_pins) == 3
 
     aresponses.assert_plan_strictly_followed()
@@ -399,14 +399,14 @@ async def test_remove_reserved_pin(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         with pytest.raises(PinError) as err:
-            await system.remove_pin("master")
+            await system.async_remove_pin("master")
             assert "Refusing to delete reserved PIN" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -430,12 +430,12 @@ async def test_set_duplicate_pin(aresponses, v3_server, v3_settings_response):
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PinError) as err:
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             system = systems[TEST_SYSTEM_ID]
-            await system.set_pin("whatever", "1234")
+            await system.async_set_pin("whatever", "1234")
             assert "Refusing to create duplicate PIN" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -452,14 +452,14 @@ async def test_set_invalid_property(aresponses, v3_server, v3_settings_response)
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         with pytest.raises(ValueError):
-            await system.set_properties({"Fake": "News"})
+            await system.async_set_properties({"Fake": "News"})
 
     aresponses.assert_plan_strictly_followed()
 
@@ -510,12 +510,12 @@ async def test_set_max_user_pins(
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PinError) as err:
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             system = systems[TEST_SYSTEM_ID]
-            await system.set_pin("whatever", "8121")
+            await system.async_set_pin("whatever", "8121")
             assert "Refusing to create more than" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -554,17 +554,17 @@ async def test_set_pin(aresponses, v3_server, v3_settings_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        latest_pins = await system.get_pins()
+        latest_pins = await system.async_get_pins()
         assert len(latest_pins) == 4
 
-        await system.set_pin("whatever", "1274")
-        latest_pins = await system.get_pins()
+        await system.async_set_pin("whatever", "1274")
+        latest_pins = await system.async_get_pins()
         assert len(latest_pins) == 5
 
     aresponses.assert_plan_strictly_followed()
@@ -575,13 +575,13 @@ async def test_set_pin_wrong_chars(aresponses, v3_server):
     """Test throwing an error when setting a PIN with non-digits."""
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PinError) as err:
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             system = systems[TEST_SYSTEM_ID]
 
-            await system.set_pin("whatever", "abcd")
+            await system.async_set_pin("whatever", "abcd")
             assert "PINs can only contain numbers" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -592,13 +592,13 @@ async def test_set_pin_wrong_length(aresponses, v3_server):
     """Test throwing an error when setting a PIN with the wrong length."""
     async with aiohttp.ClientSession() as session:
         with pytest.raises(PinError) as err:
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
-            systems = await simplisafe.get_systems()
+            systems = await simplisafe.async_get_systems()
             system = systems[TEST_SYSTEM_ID]
 
-            await system.set_pin("whatever", "1122334455")
+            await system.async_set_pin("whatever", "1122334455")
             assert "digits long" in str(err)
 
     aresponses.assert_plan_strictly_followed()
@@ -635,19 +635,19 @@ async def test_set_states(aresponses, v3_server, v3_state_response):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        await system.set_away()
+        await system.async_set_away()
         assert system.state == SystemStates.away
 
-        await system.set_home()
+        await system.async_set_home()
         assert system.state == SystemStates.home
 
-        await system.set_off()
+        await system.async_set_off()
         assert system.state == SystemStates.off
 
     aresponses.assert_plan_strictly_followed()
@@ -657,10 +657,10 @@ async def test_set_states(aresponses, v3_server, v3_state_response):
 async def test_system_notifications(aresponses, v3_server):
     """Test getting system notifications."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert len(system.notifications) == 1
 
@@ -693,14 +693,14 @@ async def test_unavailable_endpoint(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         with pytest.raises(EndpointUnavailableError):
-            await system.update(include_subscription=False, include_devices=False)
+            await system.async_update(include_subscription=False, include_devices=False)
 
     aresponses.assert_plan_strictly_followed()
 
@@ -734,13 +734,13 @@ async def test_update_system_data(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
-        await system.update()
+        await system.async_update()
 
         assert system.serial == TEST_SYSTEM_SERIAL_NO
         assert system.system_id == TEST_SYSTEM_ID
@@ -778,7 +778,7 @@ async def test_update_error(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE,
             TEST_CODE_VERIFIER,
             session=session,
@@ -786,10 +786,10 @@ async def test_update_error(
             request_retries=1,
         )
 
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
 
         with pytest.raises(RequestError):
-            await system.update()
+            await system.async_update()
 
     aresponses.assert_plan_strictly_followed()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,7 @@ async def test_401_bad_credentials(aresponses, invalid_authorization_code_respon
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.from_auth(
+            await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
 
@@ -60,10 +60,10 @@ async def test_401_refresh_token_failure(
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            simplisafe = await API.from_auth(
+            simplisafe = await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
-            await simplisafe.get_systems()
+            await simplisafe.async_get_systems()
 
     aresponses.assert_plan_strictly_followed()
 
@@ -109,12 +109,12 @@ async def test_401_refresh_token_success(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
 
         # If this succeeds without throwing an exception, the retry is successful:
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
         assert simplisafe.access_token == "jjhhgg66"
         assert simplisafe.refresh_token == "aabbcc11"
 
@@ -135,13 +135,13 @@ async def test_403_bad_credentials(aresponses, invalid_authorization_code_respon
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.from_auth(
+            await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
             )
 
 
 @pytest.mark.asyncio
-async def test_client_from_authorization_code(
+async def test_client_async_from_authorization_code(
     api_token_response, aresponses, auth_check_response
 ):
     """Test creating a client from an authorization code."""
@@ -159,7 +159,7 @@ async def test_client_from_authorization_code(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
         assert simplisafe.access_token == TEST_ACCESS_TOKEN
@@ -169,7 +169,7 @@ async def test_client_from_authorization_code(
 
 
 @pytest.mark.asyncio
-async def test_client_from_refresh_token(
+async def test_client_async_from_refresh_token(
     api_token_response, aresponses, auth_check_response
 ):
     """Test creating a client from a refresh token."""
@@ -187,7 +187,9 @@ async def test_client_from_refresh_token(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_refresh_token(TEST_REFRESH_TOKEN, session=session)
+        simplisafe = await API.async_from_refresh_token(
+            TEST_REFRESH_TOKEN, session=session
+        )
         assert simplisafe.access_token == TEST_ACCESS_TOKEN
         assert simplisafe.refresh_token == TEST_REFRESH_TOKEN
 
@@ -238,7 +240,7 @@ async def test_refresh_token_listener_callback(
     mock_listener_2 = Mock()
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
 
@@ -250,7 +252,7 @@ async def test_refresh_token_listener_callback(
         remove = simplisafe.add_refresh_token_listener(mock_listener_2)
         remove()
 
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
         mock_listener_1.assert_called_once_with("aabbcc11")
         assert mock_listener_2.call_count == 0
 
@@ -272,7 +274,7 @@ async def test_request_error_failed_retry(aresponses, server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE,
             TEST_CODE_VERIFIER,
             session=session,
@@ -281,7 +283,7 @@ async def test_request_error_failed_retry(aresponses, server):
         )
 
         with pytest.raises(RequestError):
-            await simplisafe.get_systems()
+            await simplisafe.async_get_systems()
 
     aresponses.assert_plan_strictly_followed()
 
@@ -323,12 +325,12 @@ async def test_request_error_successful_retry(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
 
         # If this succeeds without throwing an exception, the retry is successful:
-        await simplisafe.get_systems()
+        await simplisafe.async_get_systems()
 
     aresponses.assert_plan_strictly_followed()
 
@@ -345,7 +347,7 @@ async def test_string_response(aresponses):
 
     async with aiohttp.ClientSession() as session:
         with pytest.raises(InvalidCredentialsError):
-            await API.from_auth(
+            await API.async_from_auth(
                 TEST_AUTHORIZATION_CODE,
                 TEST_CODE_VERIFIER,
                 session=session,

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -18,11 +18,11 @@ from .common import (
 async def test_properties(aresponses, v3_server):
     """Test that camera properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
 
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         camera = system.cameras[TEST_CAMERA_ID]
         assert camera.name == "Camera"
@@ -45,11 +45,11 @@ async def test_properties(aresponses, v3_server):
 async def test_video_urls(aresponses, v3_server):
     """Test that camera video URL is configured properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
 
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         camera = system.cameras[TEST_CAMERA_ID]
         assert (

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -47,18 +47,18 @@ async def test_lock_unlock(aresponses, v3_lock_state_response, v3_server):
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
         assert lock.state == LockStates.locked
 
-        await lock.unlock()
+        await lock.async_unlock()
         assert lock.state == LockStates.unlocked
 
-        await lock.lock()
+        await lock.async_lock()
         assert lock.state == LockStates.locked
 
     aresponses.assert_plan_strictly_followed()
@@ -68,10 +68,10 @@ async def test_lock_unlock(aresponses, v3_lock_state_response, v3_server):
 async def test_jammed(aresponses, v3_server):
     """Test that a jammed lock shows the correct state."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID_2]
         assert lock.state is LockStates.jammed
@@ -100,18 +100,18 @@ async def test_no_state_change_on_failure(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE,
             TEST_CODE_VERIFIER,
             session=session,
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
         assert lock.state == LockStates.locked
 
         with pytest.raises(InvalidCredentialsError):
-            await lock.unlock()
+            await lock.async_unlock()
         assert lock.state == LockStates.locked
 
     aresponses.assert_plan_strictly_followed()
@@ -121,10 +121,10 @@ async def test_no_state_change_on_failure(
 async def test_properties(aresponses, v3_server):
     """Test that lock properties are created properly."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
         assert not lock.disabled
@@ -143,10 +143,10 @@ async def test_properties(aresponses, v3_server):
 async def test_unknown_state(aresponses, caplog, v3_server):
     """Test handling a generic error during update."""
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID_3]
         assert lock.state == LockStates.unknown
@@ -192,19 +192,19 @@ async def test_update(
     )
 
     async with aiohttp.ClientSession() as session:
-        simplisafe = await API.from_auth(
+        simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
-        systems = await simplisafe.get_systems()
+        systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
         assert lock.state == LockStates.locked
 
-        await lock.unlock()
+        await lock.async_unlock()
         assert lock.state == LockStates.unlocked
 
         # Simulate a manual lock and an update some time later:
-        await lock.update()
+        await lock.async_update()
         assert lock.state == LockStates.locked
 
     aresponses.assert_plan_strictly_followed()


### PR DESCRIPTION
**Breaking Change**

Coroutines now start with `async_`.

**Describe what the PR does:**

As a best practice, this PR modifies coroutines to start with `async_` (so as to easily delineate them).

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
