### PR TITLE
Ensure that the refresh token is only used within the expiration window

### DIFF
--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -232,6 +232,10 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
         simplisafe = await API.async_from_auth(
             TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
         )
+
+        # Manually set the expiration datetime to force a refresh token flow:
+        simplisafe._access_token_expire_dt = datetime.utcnow()
+
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.state == SystemStates.off

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,5 +1,7 @@
 """Define tests for the Lock objects."""
-# pylint: disable=unused-argument
+# pylint: disable=protected-access,unused-argument
+from datetime import datetime
+
 import aiohttp
 import pytest
 
@@ -105,6 +107,10 @@ async def test_no_state_change_on_failure(
             TEST_CODE_VERIFIER,
             session=session,
         )
+
+        # Manually set the expiration datetime to force a refresh token flow:
+        simplisafe._access_token_expire_dt = datetime.utcnow()
+
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]


### PR DESCRIPTION
**Describe what the PR does:**

Previously, when a request would encounter a 401 backoff, the library would attempt to refresh the access token for each of those requests, often leading to collisions where the refresh token would become invalid. This PR ensures that backoff will only try the refresh token if the last time it was used is outside of the expiration window.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
