### PR TITLE
Use an `asyncio` lock for backoff-based refresh token attempts

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -30,7 +30,7 @@ from simplipy.websocket import WebsocketClient
 API_URL_HOSTNAME = "api.simplisafe.com"
 API_URL_BASE = f"https://{API_URL_HOSTNAME}/v1"
 
-DEFAULT_EXPIRATION_PADDING = 60
+DEFAULT_EXPIRATION_PADDING = 300
 DEFAULT_REQUEST_RETRIES = 4
 DEFAULT_TIMEOUT = 10
 


### PR DESCRIPTION
**Describe what the PR does:**

Even though https://github.com/bachya/simplisafe-python/pull/266 was a needed fix, there was still a possibility that multiple "backing-off" requests could attempt the refresh token flow at the same time (causing the same problem that https://github.com/bachya/simplisafe-python/pull/266 was trying to solve). This PR augments things with an `asyncio` lock to ensure that only one such task can attempt to refresh at a given time.

Also, since I'm in here, this PR expands the access token expiration padding to give us a little more room.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
