### PR TITLE
Automatically set state after system change

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -67,15 +67,6 @@ class SystemStates(Enum):
     unknown = 99
 
 
-def coerce_state_from_raw_value(value: str) -> SystemStates:
-    """Return a proper state from a string input."""
-    try:
-        return SystemStates[convert_to_underscore(value)]
-    except KeyError:
-        LOGGER.error("Unknown raw system state: %s", value)
-        return SystemStates.unknown
-
-
 def get_device_type_from_data(device_data: dict[str, Any]) -> DeviceTypes:
     """Get the device type of a raw data payload."""
     try:
@@ -423,8 +414,12 @@ class System:
         ]
 
         # Set the current state:
-        self._state = coerce_state_from_raw_value(
-            self._api.subscription_data[self._sid]["location"]["system"].get(
-                "alarmState"
-            )
+        raw_state = self._api.subscription_data[self._sid]["location"]["system"].get(
+            "alarmState"
         )
+
+        try:
+            self._state = SystemStates[convert_to_underscore(raw_state)]
+        except KeyError:
+            LOGGER.error("Unknown raw system state: %s", raw_state)
+            self._state = SystemStates.unknown

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -9,7 +9,6 @@ from simplipy.system import (
     DEFAULT_MAX_USER_PINS,
     System,
     SystemStates,
-    coerce_state_from_raw_value,
     get_device_type_from_data,
 )
 
@@ -43,14 +42,13 @@ class SystemV2(System):
 
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
-        state_resp = await self._api.request(
+        await self._api.request(
             "post",
             f"subscriptions/{self.system_id}/state",
             params={"state": value.name},
         )
 
-        if state_resp["success"]:
-            self._state = coerce_state_from_raw_value(state_resp["requestedState"])
+        self._state = value
 
     async def _async_set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -17,7 +17,6 @@ from simplipy.system import (
     DEFAULT_MAX_USER_PINS,
     System,
     SystemStates,
-    coerce_state_from_raw_value,
     get_device_type_from_data,
     guard_from_missing_data,
 )
@@ -345,11 +344,11 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
-        state_resp = await self._api.request(
+        await self._api.request(
             "post", f"ss3/subscriptions/{self.system_id}/state/{value.name}"
         )
 
-        self._state = coerce_state_from_raw_value(state_resp["state"])
+        self._state = value
         self._last_state_change_dt = datetime.utcnow()
 
     async def _async_set_updated_pins(self, pins: dict) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

Currently, after arming/disarming the system, `simplipy` attempts to use the response JSON to store the system state. However, lately, I've been seeing this in Home Assistant logs:

```
Logger: simplipy
Source: /usr/local/lib/python3.9/site-packages/simplipy/system/__init__.py:75
First occurred: 1:58:01 AM (1 occurrences) 
Last logged: 1:58:01 AM

Unknown raw system state:
```

This means that sometimes, the request succeeds, but the response JSON contains an empty value for the system state. While thinking about how to handle this, I realized that defining the system state based upon response JSON is silly: if our request to arm/disarm the system succeeds, we should just set the appropriate state right away.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
