### PR TITLE
Make system update run coroutines in order (and not simultaneously)

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -81,6 +81,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.request = backoff.on_exception(
             backoff.expo,
             ClientResponseError,
+            jitter=backoff.random_jitter,
             logger=LOGGER,
             max_tries=request_retries,
             on_backoff=self._async_handle_on_backoff,

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -1,7 +1,6 @@
 """Define V2 and V3 SimpliSafe systems."""
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -388,14 +387,12 @@ class System:
         :param cached: Whether to used cached data.
         :type cached: ``bool``
         """
-        update_tasks = []
         if include_subscription:
-            update_tasks.append(self._async_update_subscription_data())
+            await self._async_update_subscription_data()
         if include_settings:
-            update_tasks.append(self._async_update_settings_data(cached))
+            await self._async_update_settings_data(cached)
         if include_devices:
-            update_tasks.append(self._async_update_device_data(cached))
-        await asyncio.gather(*update_tasks)
+            await self._async_update_device_data(cached)
 
         # Create notifications:
         self._notifications = [


### PR DESCRIPTION
**Describe what the PR does:**

After some investigation, I believe that our current method of updating a system (in which its underlying tasks, like updating settings/devices/etc., are executed simultaneously) is causing the frequent amount of `HTTP 409` responses from SimpliSafe. So, this PR changes things to execute those tasks in order, one after the other – it won't permanently "fix" the 490s (since SimpliSafe's architecture, wherein the base station is not regularly updated with the cloud, will necessitate syncing), but it should reduce the vast majority of them.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
