### PR TITLE
Increase websocket watchdog timeout to 5 minutes

### DIFF
--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:
 
 WEBSOCKET_SERVER_URL = "wss://socketlink.prd.aser.simplisafe.com"
 
-DEFAULT_WATCHDOG_TIMEOUT = timedelta(minutes=1)
+DEFAULT_WATCHDOG_TIMEOUT = timedelta(minutes=5)
 
 EVENT_ALARM_CANCELED = "alarm_canceled"
 EVENT_ALARM_TRIGGERED = "alarm_triggered"


### PR DESCRIPTION
**Describe what the PR does:**

In thinking about it, a 60-second watchdog timeout is a bit aggressive. This PR extends it to 5 minutes.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
