### PR TITLE
Fix bug with receipt of websocket event not triggering watchdog

### DIFF
--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -261,6 +261,8 @@ class WebsocketClient:
 
         LOGGER.debug("Received data from websocket server: %s", data)
 
+        self._watchdog.trigger()
+
         return cast(Dict[str, Any], data)
 
     async def _async_send_json(self, payload: dict[str, Any]) -> None:


### PR DESCRIPTION
**Describe what the PR does:**

The websocket watchdog wasn't triggering when we received events. 🤦🏻 This PR fixes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
