### PR TITLE
Migrate versioning to CalVer

### DIFF
--- a/script/release
+++ b/script/release
@@ -1,12 +1,7 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -e
 
 REPO_PATH="$( dirname "$( cd "$(dirname "$0")" ; pwd -P )" )"
-
-if [ -z "$1" ]; then
-    echo "Usage: script/release [patch | minor | major]"
-    exit 1
-fi
 
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "dev" ]; then
     echo "Refusing to publish a release from a branch other than dev"
@@ -18,23 +13,34 @@ if [ -z "$(command -v poetry)" ]; then
     exit 1
 fi
 
-# Make sure the latest dev is pulled:
-git pull origin dev
+function generate_version {
+    latest_tag="$(git tag --sort=committerdate | tail -1)"
+    month="$(date +'%Y.%m')"
+
+    if [[ "$latest_tag" =~ "$month".* ]]; then
+        patch="$(echo "$latest_tag" | cut -d . -f 3)"
+        ((patch=patch+1))
+        echo "$month.$patch"
+    else
+        echo "$month.0"
+    fi
+}
 
 # Temporarily uninstall pre-commit hooks so that we can push to dev and master:
 pre-commit uninstall
 
-old_version="$(poetry version | awk -F' ' '{ print $2 }')"
+# Pull the latest dev:
+git pull origin dev
 
-poetry version "$1"
+# Generate the next version (in the format YEAR.MONTH.RELEASE_NUMER):
+new_version=$(generate_version)
 
 # Update the PyPI package version:
-new_version="$(poetry version | awk -F' ' '{ print $2 }')"
+sed -i "" "s/^version = \".*\"/version = \"$new_version\"/g" "$REPO_PATH/pyproject.toml"
 git add pyproject.toml
 
 # Update the docs version:
-sphinx_conf=$(sed "s/$old_version/$new_version/g" "$REPO_PATH/docs/conf.py")
-echo "$sphinx_conf" > "$REPO_PATH/docs/conf.py"
+sed -i "" "s/^release = \".*\"/release = \"$new_version\"/g" "$REPO_PATH/docs/conf.py"
 git add docs/conf.py
 
 # Commit, tag, and push:


### PR DESCRIPTION
**Describe what the PR does:**

After much consideration, I've decided I want to move from [Semantic Versioning](https://semver.org) ("SemVer") to [Calendar Versioning](https://calver.org) ("CalVer") so that I can avoid the typical issues associated with SemVer (like a number indicating a more "mature" library than what exists).

In general, the library will now follow a version format of `YEAR.MONTH.PATCH`. There is no special significance to the `0` patch; instead, users should understand these examples:

* `YEAR.MONTH.0` is merely the first release of that month (regardless of where in the month it happens).
* `YEAR.MONTH.3` is the third release of the month.

This PR focuses on updating the release script.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
