### PR TITLE
Pin `docutils` to <0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4.post0"
 backoff = "^1.11.1"
+docutils = "<0.18"
 python = "^3.8.0"
 pytz = ">=2019.3,<2022.0"
 voluptuous = ">=0.11.7,<0.13.0"


### PR DESCRIPTION
**Describe what the PR does:**

A recent `docutils` update broke our Read The Docs. One of their members [suggested](https://github.com/sphinx-doc/sphinx/issues/9727#issuecomment-952313820) suggested pinning `docutils` to be <0.18, so this PR accomplishes that.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
