### PR TITLE
Add clarification to auth section of Usage docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -98,7 +98,8 @@ steps from a command line:
 8. Return to ``Tab 1``. The browser will show an error about not being able to navigate
    to the page (if you still see a SimpliSafe authorization pending screen, wait a
    moment for the page to refresh). Ignore this error. Instead, take a look at the URL
-   and note the ``code`` parameter at the very end:
+   (making sure it starts with ``com.simplisafe.mobile``) and note the ``code``
+   parameter at the very end:
 
 .. code::
 


### PR DESCRIPTION
**Describe what the PR does:**

Some users are attempting to get the OAuth code from the wrong URL on SimpliSafe's website. This PR updates the docs to instruct them to wait for the correct URL to appear.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
