### PR TITLE
Add more specific browser information to Authentication docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,7 @@ API
 Websocket Communication
 -----------------------
 
-.. autoclass:: simplipy.websocket.Websocket
+.. autoclass:: simplipy.websocket.WebsocketClient
    :members:
 
 .. autoclass:: simplipy.websocket.WebsocketEvent

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -83,8 +83,8 @@ steps from a command line:
 .. image:: images/ss-login-screen.png
    :width: 400
 
-6. Check your email; you should see an email from SimpliSafe™ asking you to verify the
-   new authentication request:
+6. You will be prompted to verify your account. Depending on what you have configured in
+   your SimpliSafe™ account, this could take the form of an email or an SMS:
 
 .. image:: images/ss-verification-email.png
    :width: 400
@@ -95,11 +95,15 @@ steps from a command line:
 .. image:: images/ss-verification-confirmed.png
    :width: 400
 
-8. Return to ``Tab 1``. The browser will show an error about not being able to navigate
-   to the page (if you still see a SimpliSafe authorization pending screen, wait a
-   moment for the page to refresh). Ignore this error. Instead, take a look at the URL
-   (making sure it starts with ``com.simplisafe.mobile``) and note the ``code``
-   parameter at the very end:
+8. Return to ``Tab 1``. You need to find an authorization code; the location of this
+   code will be different depending on which browser you use:
+
+   * Safari: ``Develop -> Show Web Inspector -> Network Tab`` (look for a reference to ``ErrorPage.html``)
+   * Edge: ``Developer -> Developer Tools -> Console Tab`` (look for a ``Failed to launch`` error)
+   * Chrome: ``Developer -> Developer Tools -> Console Tab`` (look for a ``Failed to launch`` error)
+
+   Look for a reference to a SimpliSafe™ iOS URL (starting with with
+   ``com.simplisafe.mobile``) and note the ``code`` parameter at the very end:
 
 .. code::
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -96,7 +96,9 @@ steps from a command line:
    :width: 400
 
 8. Return to ``Tab 1``. The browser will show an error about not being able to navigate
-   to the page; ignore it. Instead, take a look at the URL and note the ``code``
+   to the page (if you still see a SimpliSafe authorization pending screen, wait a
+   moment for the page to refresh). Ignore this error. Instead, take a look at the URL
+   (making sure it starts with ``com.simplisafe.mobile``) and note the ``code``
    parameter at the very end:
 
 .. code::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = "^3.7.4.post0"
 backoff = "^1.11.1"
+docutils = "<0.18"
 python = "^3.8.0"
 pytz = ">=2019.3,<2022.0"
 voluptuous = ">=0.11.7,<0.13.0"


### PR DESCRIPTION
**Describe what the PR does:**

It turns out that my instructions for getting the auth code were Safari-specific. This PR adds some more information for other browsers.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
