### PR TITLE
Use V3 system properties constants

### DIFF
--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -43,15 +43,15 @@ VOLUME_HIGH = 3
 VOLUMES = [VOLUME_OFF, VOLUME_LOW, VOLUME_MEDIUM, VOLUME_HIGH]
 
 SYSTEM_PROPERTIES_VALUE_MAP = {
-    "alarm_duration": "alarmDuration",
-    "alarm_volume": "alarmVolume",
-    "chime_volume": "doorChime",
-    "entry_delay_away": "entryDelayAway",
-    "entry_delay_home": "entryDelayHome",
-    "exit_delay_away": "exitDelayAway",
-    "exit_delay_home": "exitDelayHome",
-    "light": "light",
-    "voice_prompt_volume": "voicePrompts",
+    CONF_ALARM_DURATION: "alarmDuration",
+    CONF_ALARM_VOLUME: "alarmVolume",
+    CONF_CHIME_VOLUME: "doorChime",
+    CONF_ENTRY_DELAY_AWAY: "entryDelayAway",
+    CONF_ENTRY_DELAY_HOME: "entryDelayHome",
+    CONF_EXIT_DELAY_AWAY: "exitDelayAway",
+    CONF_EXIT_DELAY_HOME: "exitDelayHome",
+    CONF_LIGHT: "light",
+    CONF_VOICE_PROMPT_VOLUME: "voicePrompts",
 }
 
 SYSTEM_PROPERTIES_PAYLOAD_SCHEMA = vol.Schema(


### PR DESCRIPTION
**Describe what the PR does:**

This PR uses some already-defined constants (rather than defining new strings) in the V3 system properties map.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
