### PR TITLE
Use enum for V3 volume property values

### DIFF
--- a/docs/system.rst
+++ b/docs/system.rst
@@ -180,42 +180,35 @@ V3 systems also come with a :meth:`async_set_properties <simplipy.system.v3.Syst
 method to update the following system properties:
 
 * ``alarm_duration`` (in seconds): 30-480
-* ``alarm_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
-* ``chime_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
+* ``alarm_volume``: Volume.OFF, Volume.LOW, Volume.MEDIUM, Volume.HIGH
+* ``chime_volume``: Volume.OFF, Volume.LOW, Volume.MEDIUM, Volume.HIGH
 * ``entry_delay_away`` (in seconds): 30-255
 * ``entry_delay_home`` (in seconds): 0-255
 * ``exit_delay_away`` (in seconds): 45-255
 * ``exit_delay_home`` (in seconds): 0-255
 * ``light``: True or False
-* ``voice_prompt_volume``: 0 (off), 1 (low), 2 (medium), 3 (high)
+* ``voice_prompt_volume``: Volume.OFF, Volume.LOW, Volume.MEDIUM, Volume.HIGH
 
-Note that volume properties can accept integers or constants defined in
-``simplipy.system.v3.SystemV3``.
+Note that the ``simplipy.system.v3.Volume`` enum class should be used for volume
+properties.
 
 .. code:: python
 
-    from simplipy.system.v3 import VOLUME_OFF, VOLUME_LOW, VOLUME_MEDIUM
+    from simplipy.system.v3 import Volume
 
     await system.async_set_properties(
         {
             "alarm_duration": 240,
-            "alarm_volume": VOLUME_HIGH,
-            "chime_volume": VOLUME_MEDIUM,
+            "alarm_volume": Volume.HIGH,
+            "chime_volume": Volume.MEDIUM,
             "entry_delay_away": 30,
             "entry_delay_home": 30,
             "exit_delay_away": 60,
             "exit_delay_home": 0,
             "light": True,
-            "voice_prompt_volume": VOLUME_MEDIUM,
+            "voice_prompt_volume": Volume.MEDIUM,
         }
     )
-
-Note that entry and exit delay durations have limits imposed:
-
-* Entry Delay (``away``): 30–255 seconds
-* Entry Delay (``home``): 45–255 seconds
-* Exit Delay (``away``): 0–255 seconds
-* Exit Delay (``home``): 0–255 seconds
 
 Attempting to call these coroutines with a value beyond these limits will raise a
 :meth:`SimplipyError <simplipy.errors.SimplipyError>`.

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -16,7 +16,7 @@ from simplipy.errors import (
     SimplipyError,
 )
 from simplipy.system import SystemStates
-from simplipy.system.v3 import VOLUME_HIGH, VOLUME_MEDIUM
+from simplipy.system.v3 import Volume
 
 from tests.common import (
     TEST_AUTHORIZATION_CODE,
@@ -264,9 +264,9 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.alarm_duration == 240
-        assert system.alarm_volume == VOLUME_HIGH
+        assert system.alarm_volume == Volume.HIGH.value
         assert system.battery_backup_power_level == 5293
-        assert system.chime_volume == VOLUME_MEDIUM
+        assert system.chime_volume == Volume.MEDIUM.value
         assert system.connection_type == "wifi"
         assert system.entry_delay_away == 30
         assert system.entry_delay_home == 30
@@ -277,7 +277,7 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         assert system.offline is False
         assert system.power_outage is False
         assert system.rf_jamming is False
-        assert system.voice_prompt_volume == VOLUME_MEDIUM
+        assert system.voice_prompt_volume == Volume.MEDIUM.value
         assert system.wall_power_level == 5933
         assert system.wifi_ssid == "MY_WIFI"
         assert system.wifi_strength == -49
@@ -297,25 +297,25 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         await system.async_set_properties(
             {
                 "alarm_duration": 240,
-                "alarm_volume": VOLUME_HIGH,
-                "chime_volume": VOLUME_MEDIUM,
+                "alarm_volume": Volume.HIGH,
+                "chime_volume": Volume.MEDIUM,
                 "entry_delay_away": 30,
                 "entry_delay_home": 30,
                 "exit_delay_away": 60,
                 "exit_delay_home": 0,
                 "light": True,
-                "voice_prompt_volume": VOLUME_MEDIUM,
+                "voice_prompt_volume": Volume.MEDIUM,
             }
         )
         assert system.alarm_duration == 240
-        assert system.alarm_volume == VOLUME_HIGH
-        assert system.chime_volume == VOLUME_MEDIUM
+        assert system.alarm_volume == Volume.HIGH.value
+        assert system.chime_volume == Volume.MEDIUM.value
         assert system.entry_delay_away == 30
         assert system.entry_delay_home == 30
         assert system.exit_delay_away == 60
         assert system.exit_delay_home == 0
         assert system.light is True
-        assert system.voice_prompt_volume == VOLUME_MEDIUM
+        assert system.voice_prompt_volume == Volume.MEDIUM.value
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

Previously, V3 volume values were stored as constants. This doesn't really jive with the rest of the library, where a constrained set of values are placed in enums. This PR moves volume levels into a single enum.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
