### PR TITLE
Make all enum values uppercase

### DIFF
--- a/docs/lock.rst
+++ b/docs/lock.rst
@@ -27,7 +27,7 @@ All :meth:`Lock <simplipy.lock.Lock>` objects come with a standard set of proper
 
         # Return the state of the lock:
         lock.state
-        # >>> simplipy.lock.LockStates.locked
+        # >>> simplipy.lock.LockStates.LOCKED
 
         # Return whether the lock is in an error state:
         lock.error

--- a/docs/sensor.rst
+++ b/docs/sensor.rst
@@ -38,7 +38,7 @@ All ``Sensor`` objects come with a standard set of properties
 
         # Return the sensor's type:
         sensor.type
-        # >>> simplipy.DeviceTypes.glass_break
+        # >>> simplipy.DeviceTypes.GLASS_BREAK
 
         # Return whether the sensor is in an error state:
         sensor.error

--- a/docs/system.rst
+++ b/docs/system.rst
@@ -74,7 +74,7 @@ properties:
 
     # Return the current state of the system:
     system.state
-    # >>> simplipy.system.SystemStates.away
+    # >>> simplipy.system.SystemStates.AWAY
 
     # Return the SimpliSafe™ identifier for this system
     # from the key:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ sphinx-rtd-theme = "^1.0.0"
 types-pytz = "^2021.1.0"
 
 [tool.pylint.BASIC]
-class-const-naming-style = "any"
 expected-line-ending-format = "LF"
 
 [tool.pylint."MESSAGES CONTROL"]

--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -11,24 +11,24 @@ if TYPE_CHECKING:
 class DeviceTypes(Enum):
     """Device types based on internal SimpliSafe ID number."""
 
-    remote = 0
-    keypad = 1
-    keychain = 2
-    panic_button = 3
-    motion = 4
-    entry = 5
-    glass_break = 6
-    carbon_monoxide = 7
-    smoke = 8
-    leak = 9
-    temperature = 10
-    camera = 12
-    siren = 13
-    doorbell = 15
-    lock = 16
-    outdoor_camera = 17
-    lock_keypad = 253
-    unknown = 99
+    REMOTE = 0
+    KEYPAD = 1
+    KEYCHAIN = 2
+    PANIC_BUTTON = 3
+    MOTION = 4
+    ENTRY = 5
+    GLASS_BREAK = 6
+    CARBON_MONOXIDE = 7
+    SMOKE = 8
+    LEAK = 9
+    TEMPERATURE = 10
+    CAMERA = 12
+    SIREN = 13
+    DOORBELL = 15
+    LOCK = 16
+    OUTDOOR_CAMERA = 17
+    LOCK_KEYPAD = 253
+    UNKNOWN = 99
 
 
 class Device:

--- a/simplipy/device/lock.py
+++ b/simplipy/device/lock.py
@@ -12,10 +12,10 @@ if TYPE_CHECKING:
 class LockStates(Enum):
     """States that a lock can be in."""
 
-    unlocked = 0
-    locked = 1
-    jammed = 2
-    unknown = 99
+    UNLOCKED = 0
+    LOCKED = 1
+    JAMMED = 2
+    UNKNOWN = 99
 
 
 class Lock(DeviceV3):
@@ -37,8 +37,8 @@ class Lock(DeviceV3):
     class _InternalStates(Enum):
         """Define an enum to map internal lock states to values we understand."""
 
-        locked = 1
-        unlocked = 2
+        LOCKED = 1
+        UNLOCKED = 2
 
     def __init__(
         self,
@@ -99,7 +99,7 @@ class Lock(DeviceV3):
         :rtype: :meth:`simplipy.lock.LockStates`
         """
         if bool(self._system.sensor_data[self._serial]["status"]["lockJamState"]):
-            return LockStates.jammed
+            return LockStates.JAMMED
 
         raw_state = self._system.sensor_data[self._serial]["status"]["lockState"]
 
@@ -107,11 +107,11 @@ class Lock(DeviceV3):
             internal_state = self._InternalStates(raw_state)
         except ValueError:
             LOGGER.error("Unknown raw lock state: %s", raw_state)
-            return LockStates.unknown
+            return LockStates.UNKNOWN
 
-        if internal_state == self._InternalStates.locked:
-            return LockStates.locked
-        return LockStates.unlocked
+        if internal_state == self._InternalStates.LOCKED:
+            return LockStates.LOCKED
+        return LockStates.UNLOCKED
 
     async def async_lock(self) -> None:
         """Lock the lock."""
@@ -124,7 +124,7 @@ class Lock(DeviceV3):
         # Update the internal state representation:
         self._system.sensor_data[self._serial]["status"][
             "lockState"
-        ] = self._InternalStates.locked.value
+        ] = self._InternalStates.LOCKED.value
 
     async def async_unlock(self) -> None:
         """Unlock the lock."""
@@ -137,4 +137,4 @@ class Lock(DeviceV3):
         # Update the internal state representation:
         self._system.sensor_data[self._serial]["status"][
             "lockState"
-        ] = self._InternalStates.unlocked.value
+        ] = self._InternalStates.UNLOCKED.value

--- a/simplipy/device/sensor/v2.py
+++ b/simplipy/device/sensor/v2.py
@@ -60,7 +60,7 @@ class SensorV2(Device):
 
         :rtype: ``bool``
         """
-        if self.type == DeviceTypes.entry:
+        if self.type == DeviceTypes.ENTRY:
             return cast(
                 bool,
                 self._system.sensor_data[self._serial].get("entryStatus", "closed")

--- a/simplipy/device/sensor/v3.py
+++ b/simplipy/device/sensor/v3.py
@@ -31,13 +31,13 @@ class SensorV3(DeviceV3):
         :rtype: ``bool``
         """
         if self.type in (
-            DeviceTypes.carbon_monoxide,
-            DeviceTypes.entry,
-            DeviceTypes.glass_break,
-            DeviceTypes.leak,
-            DeviceTypes.motion,
-            DeviceTypes.smoke,
-            DeviceTypes.temperature,
+            DeviceTypes.CARBON_MONOXIDE,
+            DeviceTypes.ENTRY,
+            DeviceTypes.GLASS_BREAK,
+            DeviceTypes.LEAK,
+            DeviceTypes.MOTION,
+            DeviceTypes.SMOKE,
+            DeviceTypes.TEMPERATURE,
         ):
             return cast(
                 bool,
@@ -56,7 +56,7 @@ class SensorV3(DeviceV3):
 
         :rtype: ``int``
         """
-        if self.type != DeviceTypes.temperature:
+        if self.type != DeviceTypes.TEMPERATURE:
             raise AttributeError("Non-temperature sensor cannot have a temperature")
 
         return cast(

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -49,18 +49,18 @@ class SystemNotification:
 class SystemStates(Enum):
     """States that the system can be in."""
 
-    alarm = 1
-    alarm_count = 2
-    away = 3
-    away_count = 4
-    entry_delay = 5
-    error = 6
-    exit_delay = 7
-    home = 8
-    home_count = 9
-    off = 10
-    test = 11
-    unknown = 99
+    ALARM = 1
+    ALARM_COUNT = 2
+    AWAY = 3
+    AWAY_COUNT = 4
+    ENTRY_DELAY = 5
+    ERROR = 6
+    EXIT_DELAY = 7
+    HOME = 8
+    HOME_COUNT = 9
+    OFF = 10
+    TEST = 11
+    UNKNOWN = 99
 
 
 def get_device_type_from_data(device_data: dict[str, Any]) -> DeviceTypes:
@@ -69,7 +69,7 @@ def get_device_type_from_data(device_data: dict[str, Any]) -> DeviceTypes:
         return DeviceTypes(device_data["type"])
     except ValueError:
         LOGGER.error("Unknown device type: %s", device_data["type"])
-        return DeviceTypes.unknown
+        return DeviceTypes.UNKNOWN
 
 
 def guard_from_missing_data(default_value: Any = None) -> Callable:
@@ -112,7 +112,7 @@ class System:
 
         # These will get filled in after initial update:
         self._notifications: list[SystemNotification] = []
-        self._state = SystemStates.unknown
+        self._state = SystemStates.UNKNOWN
         self.sensor_data: dict[str, dict[str, Any]] = {}
         self.sensors: dict[str, SensorV2 | SensorV3] = {}
 
@@ -320,15 +320,15 @@ class System:
 
     async def async_set_away(self) -> None:
         """Set the system in "Away" mode."""
-        await self._async_set_state(SystemStates.away)
+        await self._async_set_state(SystemStates.AWAY)
 
     async def async_set_home(self) -> None:
         """Set the system in "Home" mode."""
-        await self._async_set_state(SystemStates.home)
+        await self._async_set_state(SystemStates.HOME)
 
     async def async_set_off(self) -> None:
         """Set the system in "Off" mode."""
-        await self._async_set_state(SystemStates.off)
+        await self._async_set_state(SystemStates.OFF)
 
     async def async_set_pin(self, label: str, pin: str) -> None:
         """Set a PIN.
@@ -413,7 +413,7 @@ class System:
         )
 
         try:
-            self._state = SystemStates[convert_to_underscore(raw_state)]
+            self._state = SystemStates[convert_to_underscore(raw_state).upper()]
         except KeyError:
             LOGGER.error("Unknown raw system state: %s", raw_state)
-            self._state = SystemStates.unknown
+            self._state = SystemStates.UNKNOWN

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -45,7 +45,7 @@ class SystemV2(System):
         await self._api.request(
             "post",
             f"subscriptions/{self.system_id}/state",
-            params={"state": value.name},
+            params={"state": value.name.lower()},
         )
 
         self._state = value

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -364,7 +364,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
         await self._api.request(
-            "post", f"ss3/subscriptions/{self.system_id}/state/{value.name}"
+            "post", f"ss3/subscriptions/{self.system_id}/state/{value.name.lower()}"
         )
 
         self._state = value
@@ -409,13 +409,13 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         """Generate device objects for this system."""
         for serial, sensor in self.sensor_data.items():
             sensor_type = get_device_type_from_data(sensor)
-            if sensor_type == DeviceTypes.lock:
+            if sensor_type == DeviceTypes.LOCK:
                 self.locks[serial] = Lock(self._api.request, self, sensor_type, serial)
             else:
                 self.sensors[serial] = SensorV3(self, sensor_type, serial)
 
         for serial in self.camera_data:
-            self.cameras[serial] = Camera(self, DeviceTypes.camera, serial)
+            self.cameras[serial] = Camera(self, DeviceTypes.CAMERA, serial)
 
     async def async_get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.

--- a/tests/sensor/test_base.py
+++ b/tests/sensor/test_base.py
@@ -21,6 +21,6 @@ async def test_properties_base(aresponses, v2_server):
         sensor = system.sensors["195"]
         assert sensor.name == "Garage Keypad"
         assert sensor.serial == "195"
-        assert sensor.type == DeviceTypes.keypad
+        assert sensor.type == DeviceTypes.KEYPAD
 
     aresponses.assert_plan_strictly_followed()

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -147,7 +147,7 @@ async def test_properties(aresponses, v2_server):
         assert system.address == TEST_ADDRESS
         assert system.connection_type == "wifi"
         assert system.serial == TEST_SYSTEM_SERIAL_NO
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
         assert system.system_id == TEST_SYSTEM_ID
         assert system.temperature == 67
         assert system.version == 2

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -147,13 +147,13 @@ async def test_set_states(aresponses, v2_server, v2_state_response):
         system = systems[TEST_SYSTEM_ID]
 
         await system.async_set_away()
-        assert system.state == SystemStates.away
+        assert system.state == SystemStates.AWAY
 
         await system.async_set_home()
-        assert system.state == SystemStates.home
+        assert system.state == SystemStates.HOME
 
         await system.async_set_off()
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
 
     aresponses.assert_plan_strictly_followed()
 

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -37,7 +37,7 @@ async def test_alarm_state(aresponses, v3_server):
         )
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
 
     aresponses.assert_plan_strictly_followed()
 
@@ -178,7 +178,7 @@ async def test_lock_state_update_bug(aresponses, caplog, v3_server, v3_state_res
         system = systems[TEST_SYSTEM_ID]
 
         await system.async_set_away()
-        assert system.state == SystemStates.away
+        assert system.state == SystemStates.AWAY
 
         await system.async_update()
         assert any("Skipping system update" in e.message for e in caplog.records)
@@ -238,11 +238,11 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
 
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
 
         with pytest.raises(InvalidCredentialsError):
             await system.async_set_away()
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
 
     aresponses.assert_plan_strictly_followed()
 
@@ -646,13 +646,13 @@ async def test_set_states(aresponses, v3_server, v3_state_response):
         system = systems[TEST_SYSTEM_ID]
 
         await system.async_set_away()
-        assert system.state == SystemStates.away
+        assert system.state == SystemStates.AWAY
 
         await system.async_set_home()
-        assert system.state == SystemStates.home
+        assert system.state == SystemStates.HOME
 
         await system.async_set_off()
-        assert system.state == SystemStates.off
+        assert system.state == SystemStates.OFF
 
     aresponses.assert_plan_strictly_followed()
 

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -55,13 +55,13 @@ async def test_lock_unlock(aresponses, v3_lock_state_response, v3_server):
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
         await lock.async_unlock()
-        assert lock.state == LockStates.unlocked
+        assert lock.state == LockStates.UNLOCKED
 
         await lock.async_lock()
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
     aresponses.assert_plan_strictly_followed()
 
@@ -76,7 +76,7 @@ async def test_jammed(aresponses, v3_server):
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID_2]
-        assert lock.state is LockStates.jammed
+        assert lock.state is LockStates.JAMMED
 
     aresponses.assert_plan_strictly_followed()
 
@@ -114,11 +114,11 @@ async def test_no_state_change_on_failure(
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
         with pytest.raises(InvalidCredentialsError):
             await lock.async_unlock()
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
     aresponses.assert_plan_strictly_followed()
 
@@ -140,7 +140,7 @@ async def test_properties(aresponses, v3_server):
         assert not lock.offline
         assert not lock.pin_pad_low_battery
         assert not lock.pin_pad_offline
-        assert lock.state is LockStates.locked
+        assert lock.state is LockStates.LOCKED
 
     aresponses.assert_plan_strictly_followed()
 
@@ -155,7 +155,7 @@ async def test_unknown_state(aresponses, caplog, v3_server):
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID_3]
-        assert lock.state == LockStates.unknown
+        assert lock.state == LockStates.UNKNOWN
 
         assert any("Unknown raw lock state" in e.message for e in caplog.records)
 
@@ -204,13 +204,13 @@ async def test_update(
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         lock = system.locks[TEST_LOCK_ID]
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
         await lock.async_unlock()
-        assert lock.state == LockStates.unlocked
+        assert lock.state == LockStates.UNLOCKED
 
         # Simulate a manual lock and an update some time later:
         await lock.async_update()
-        assert lock.state == LockStates.locked
+        assert lock.state == LockStates.LOCKED
 
     aresponses.assert_plan_strictly_followed()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -75,7 +75,7 @@ def test_create_event(ws_message_event):
     assert event.changed_by == "Master PIN"
     assert event.sensor_name == ""
     assert event.sensor_serial == "abcdef12"
-    assert event.sensor_type == DeviceTypes.keypad
+    assert event.sensor_type == DeviceTypes.KEYPAD
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Enum values are really supposed to be uppercase (since, in a way, they represent constants), so this PR standardizes all enums this way.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
