### PR TITLE
Wrap guard_from_missing_decorator to fix autodoc

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
+from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, cast
 
 from simplipy.const import LOGGER
@@ -78,6 +79,7 @@ def guard_from_missing_data(default_value: Any = None) -> Callable:
     def decorator(func: Callable) -> Callable:
         """Decorate."""
 
+        @wraps(func)
         def wrapper(system: "System") -> Any:
             """Call the function and handle any issue."""
             try:


### PR DESCRIPTION
**Describe what the PR does:**

This PR properly wraps a decorator that was messing up Sphinx's autodoc.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
