### PR TITLE
Store V3 system volumes as `Volume` enums

### DIFF
--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -161,15 +161,17 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     @property  # type: ignore
     @guard_from_missing_data()
-    def alarm_volume(self) -> int:
+    def alarm_volume(self) -> Volume:
         """Return the volume level of the alarm.
 
         :rtype: ``int``
         """
-        return int(
-            self.settings_data["settings"]["normal"][
-                SYSTEM_PROPERTIES_VALUE_MAP["alarm_volume"]
-            ]
+        return Volume(
+            int(
+                self.settings_data["settings"]["normal"][
+                    SYSTEM_PROPERTIES_VALUE_MAP["alarm_volume"]
+                ]
+            )
         )
 
     @property  # type: ignore
@@ -183,15 +185,17 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     @property  # type: ignore
     @guard_from_missing_data()
-    def chime_volume(self) -> int:
+    def chime_volume(self) -> Volume:
         """Return the volume level of the door chime.
 
         :rtype: ``int``
         """
-        return int(
-            self.settings_data["settings"]["normal"][
-                SYSTEM_PROPERTIES_VALUE_MAP["chime_volume"]
-            ]
+        return Volume(
+            int(
+                self.settings_data["settings"]["normal"][
+                    SYSTEM_PROPERTIES_VALUE_MAP["chime_volume"]
+                ]
+            )
         )
 
     @property  # type: ignore
@@ -308,16 +312,17 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     @property  # type: ignore
     @guard_from_missing_data()
-    def voice_prompt_volume(self) -> int:
+    def voice_prompt_volume(self) -> Volume:
         """Return the volume level of the voice prompt.
 
         :rtype: ``int``
         """
-        return cast(
-            int,
-            self.settings_data["settings"]["normal"][
-                SYSTEM_PROPERTIES_VALUE_MAP["voice_prompt_volume"]
-            ],
+        return Volume(
+            int(
+                self.settings_data["settings"]["normal"][
+                    SYSTEM_PROPERTIES_VALUE_MAP["voice_prompt_volume"]
+                ]
+            )
         )
 
     @property  # type: ignore

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -264,9 +264,9 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]
         assert system.alarm_duration == 240
-        assert system.alarm_volume == Volume.HIGH.value
+        assert system.alarm_volume == Volume.HIGH
         assert system.battery_backup_power_level == 5293
-        assert system.chime_volume == Volume.MEDIUM.value
+        assert system.chime_volume == Volume.MEDIUM
         assert system.connection_type == "wifi"
         assert system.entry_delay_away == 30
         assert system.entry_delay_home == 30
@@ -277,7 +277,7 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
         assert system.offline is False
         assert system.power_outage is False
         assert system.rf_jamming is False
-        assert system.voice_prompt_volume == Volume.MEDIUM.value
+        assert system.voice_prompt_volume == Volume.MEDIUM
         assert system.wall_power_level == 5933
         assert system.wifi_ssid == "MY_WIFI"
         assert system.wifi_strength == -49
@@ -308,14 +308,14 @@ async def test_properties(aresponses, v3_server, v3_settings_response):
             }
         )
         assert system.alarm_duration == 240
-        assert system.alarm_volume == Volume.HIGH.value
-        assert system.chime_volume == Volume.MEDIUM.value
+        assert system.alarm_volume == Volume.HIGH
+        assert system.chime_volume == Volume.MEDIUM
         assert system.entry_delay_away == 30
         assert system.entry_delay_home == 30
         assert system.exit_delay_away == 60
         assert system.exit_delay_home == 0
         assert system.light is True
-        assert system.voice_prompt_volume == Volume.MEDIUM.value
+        assert system.voice_prompt_volume == Volume.MEDIUM
 
     aresponses.assert_plan_strictly_followed()
 


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/simplisafe-python/pull/287 introduce the `Volume` enum for V3 systems, but didn't go far enough to actually store volume levels _as_ values from this enum. This PR fixes that.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
