### PR TITLE
Centralize and standardize callback usage

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -77,6 +77,9 @@ Systems
 Utilities
 ---------
 
+.. automodule:: simplipy.util
+   :members:
+
 ``auth``
 ********
 

--- a/docs/websocket.rst
+++ b/docs/websocket.rst
@@ -33,14 +33,14 @@ Disconnecting
 Responding to Events
 --------------------
 
-Users respond to events by defining listeners (synchronous functions *or* coroutines).
+Users respond to events by defining callbacks (synchronous functions *or* coroutines).
 The following events exist:
 
 * ``connect``: occurs when the websocket connection is established
 * ``disconnect``: occurs when the websocket connection is terminated
 * ``event``: occurs when any data is transmitted from the SimpliSafe™ cloud
 
-Note that you can register as many listeners as you'd like.
+Note that you can register as many callbacks as you'd like.
 
 ``connect``
 ***********
@@ -54,10 +54,10 @@ Note that you can register as many listeners as you'd like.
     def connect_handler():
         print("I connected to the websocket")
 
-    remove_1 = simplisafe.websocket.add_connect_listener(async_connect_handler)
-    remove_2 = simplisafe.websocket.add_connect_listener(connect_handler)
+    remove_1 = simplisafe.websocket.add_connect_callback(async_connect_handler)
+    remove_2 = simplisafe.websocket.add_connect_callback(connect_handler)
 
-    # remove_1 and remove_2 are functions that, when called, remove the listener.
+    # remove_1 and remove_2 are functions that, when called, remove the callback.
 
 ``disconnect``
 **************
@@ -71,10 +71,10 @@ Note that you can register as many listeners as you'd like.
     def connect_handler():
         print("I disconnected from the websocket")
 
-    remove_1 = simplisafe.websocket.add_disconnect_listener(async_connect_handler)
-    remove_2 = simplisafe.websocket.add_disconnect_listener(connect_handler)
+    remove_1 = simplisafe.websocket.add_disconnect_callback(async_connect_handler)
+    remove_2 = simplisafe.websocket.add_disconnect_callback(connect_handler)
 
-    # remove_1 and remove_2 are functions that, when called, remove the listener.
+    # remove_1 and remove_2 are functions that, when called, remove the callback.
 
 ``event``
 *********
@@ -88,15 +88,15 @@ Note that you can register as many listeners as you'd like.
     def connect_handler():
         print(f"I received a SimpliSafe™ event: {event}")
 
-    remove_1 = simplisafe.websocket.add_event_listener(async_connect_handler)
-    remove_2 = simplisafe.websocket.add_event_listener(connect_handler)
+    remove_1 = simplisafe.websocket.add_event_callback(async_connect_handler)
+    remove_2 = simplisafe.websocket.add_event_callback(connect_handler)
 
-    # remove_1 and remove_2 are functions that, when called, remove the listener.
+    # remove_1 and remove_2 are functions that, when called, remove the callback.
 
 Response Format
 ===============
 
-The ``event`` argument provided to event listeners is a
+The ``event`` argument provided to event callbacks is a
 :meth:`simplipy.websocket.WebsocketEvent` object, which comes with several properties:
 
 * ``changed_by``: the PIN that caused the event (in the case of arming/disarming/etc.)

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -19,6 +19,7 @@ from simplipy.errors import (
 )
 from simplipy.system.v2 import SystemV2
 from simplipy.system.v3 import SystemV3
+from simplipy.util import schedule_callback
 from simplipy.util.auth import (
     AUTH_URL_BASE,
     AUTH_URL_HOSTNAME,
@@ -65,7 +66,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         request_retries: int = DEFAULT_REQUEST_RETRIES,
     ) -> None:
         """Initialize."""
-        self._refresh_token_listeners: list[Callable[..., None]] = []
+        self._refresh_token_callbacks: list[Callable[..., None]] = []
         self.session: ClientSession = session
 
         # These will get filled in after initial authentication:
@@ -215,8 +216,8 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.access_token = token_resp["access_token"]
         self.refresh_token = token_resp["refresh_token"]
 
-        for callback in self._refresh_token_listeners:
-            callback(self.refresh_token)
+        for callback in self._refresh_token_callbacks:
+            schedule_callback(callback)
 
     async def _async_request(
         self, method: str, endpoint: str, url_base: str = API_URL_BASE, **kwargs: Any
@@ -261,21 +262,21 @@ class API:  # pylint: disable=too-many-instance-attributes
 
         return data
 
-    def add_refresh_token_listener(
+    def add_refresh_token_callback(
         self, callback: Callable[..., None]
     ) -> Callable[..., None]:
-        """Add a listener that should be triggered when tokens are refreshed.
+        """Add a callback that should be triggered when tokens are refreshed.
 
         Note that callbacks should expect to receive a refresh token as a parameter.
 
         :param callback: The method to call after receiving an event.
         :type callback: ``Callable[..., None]``
         """
-        self._refresh_token_listeners.append(callback)
+        self._refresh_token_callbacks.append(callback)
 
         def remove() -> None:
             """Remove the callback."""
-            self._refresh_token_listeners.remove(callback)
+            self._refresh_token_callbacks.remove(callback)
 
         return remove
 

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -217,7 +217,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.refresh_token = token_resp["refresh_token"]
 
         for callback in self._refresh_token_callbacks:
-            schedule_callback(callback)
+            schedule_callback(callback, self.refresh_token)
 
     async def _async_request(
         self, method: str, endpoint: str, url_base: str = API_URL_BASE, **kwargs: Any

--- a/simplipy/util/__init__.py
+++ b/simplipy/util/__init__.py
@@ -1,1 +1,12 @@
 """Define utility modules."""
+import asyncio
+from typing import Any, Callable
+
+
+def schedule_callback(callback: Callable[..., Any], *args: Any) -> None:
+    """Schedule a callback to be called."""
+    if asyncio.iscoroutinefunction(callback):
+        asyncio.create_task(callback(*args))
+    else:
+        loop = asyncio.get_running_loop()
+        loop.call_soon(callback, *args)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -205,18 +205,14 @@ async def test_client_async_from_refresh_token(
 
 
 @pytest.mark.asyncio
-async def test_refresh_token_listener_callback(
+async def test_refresh_token_callback(
     api_token_response,
     aresponses,
-    caplog,
     server,
     v2_settings_response,
     v2_subscriptions_response,
 ):
-    """Test that listener callbacks are executed correctly."""
-    import logging
-
-    caplog.set_level(logging.DEBUG)
+    """Test that callback callbacks are executed correctly."""
     server.add(
         "api.simplisafe.com",
         f"/v1/users/{TEST_SUBSCRIPTION_ID}/subscriptions",
@@ -254,8 +250,8 @@ async def test_refresh_token_listener_callback(
         response=aiohttp.web_response.json_response(v2_settings_response, status=200),
     )
 
-    mock_listener_1 = Mock()
-    mock_listener_2 = Mock()
+    mock_callback_1 = Mock()
+    mock_callback_2 = Mock()
 
     async with aiohttp.ClientSession() as session:
         simplisafe = await API.async_from_auth(
@@ -265,18 +261,18 @@ async def test_refresh_token_listener_callback(
         # Manually set the expiration datetime to force a refresh token flow:
         simplisafe._access_token_expire_dt = datetime.utcnow()
 
-        # We'll hang onto one listener callback:
-        simplisafe.add_refresh_token_listener(mock_listener_1)
-        assert mock_listener_1.call_count == 0
+        # We'll hang onto one callback callback:
+        simplisafe.add_refresh_token_callback(mock_callback_1)
+        assert mock_callback_1.call_count == 0
 
         # ..and delete the a second one before ever using it:
-        remove = simplisafe.add_refresh_token_listener(mock_listener_2)
+        remove = simplisafe.add_refresh_token_callback(mock_callback_2)
         remove()
 
         await simplisafe.async_get_systems()
-        mock_listener_1.assert_called_once_with("aabbcc11")
-        assert mock_listener_1.call_count == 1
-        assert mock_listener_2.call_count == 0
+        mock_callback_1.assert_called_once_with("aabbcc11")
+        assert mock_callback_1.call_count == 1
+        assert mock_callback_2.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 """Define tests for the System object."""
 # pylint: disable=protected-access,too-many-arguments
+import asyncio
 from datetime import datetime
 from unittest.mock import Mock
 
@@ -270,6 +271,7 @@ async def test_refresh_token_callback(
         remove()
 
         await simplisafe.async_get_systems()
+        await asyncio.sleep(1)
         mock_callback_1.assert_called_once_with("aabbcc11")
         assert mock_callback_1.call_count == 1
         assert mock_callback_2.call_count == 0

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -160,8 +160,8 @@ async def test_listen_error_message_types(
 
 
 @pytest.mark.asyncio
-async def test_callback(caplog, mock_api, ws_message_event, ws_messages):
-    """Test that callback callbacks are executed correctly."""
+async def test_callbacks(caplog, mock_api, ws_message_event, ws_messages):
+    """Test that callbacks are executed correctly."""
     caplog.set_level(logging.INFO)
 
     mock_connect_callback = Mock()
@@ -184,6 +184,7 @@ async def test_callback(caplog, mock_api, ws_message_event, ws_messages):
 
     await client.async_connect()
     assert client.connected
+    await asyncio.sleep(1)
     assert mock_connect_callback.call_count == 1
     assert any("We are connected!" in e.message for e in caplog.records)
 

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -160,45 +160,45 @@ async def test_listen_error_message_types(
 
 
 @pytest.mark.asyncio
-async def test_listener_callbacks(caplog, mock_api, ws_message_event, ws_messages):
-    """Test that listener callbacks are executed correctly."""
+async def test_callback(caplog, mock_api, ws_message_event, ws_messages):
+    """Test that callback callbacks are executed correctly."""
     caplog.set_level(logging.INFO)
 
-    mock_connect_listener = Mock()
-    mock_disconnect_listener = Mock()
-    mock_event_listener = Mock()
+    mock_connect_callback = Mock()
+    mock_disconnect_callback = Mock()
+    mock_event_callback = Mock()
 
-    async def async_mock_connect_listener():
-        """Define a mock async conenct listener."""
+    async def async_mock_connect_callback():
+        """Define a mock async conenct callback."""
         LOGGER.info("We are connected!")
 
     client = WebsocketClient(mock_api)
-    client.add_connect_listener(mock_connect_listener)
-    client.add_connect_listener(async_mock_connect_listener)
-    client.add_disconnect_listener(mock_disconnect_listener)
-    client.add_event_listener(mock_event_listener)
+    client.add_connect_callback(mock_connect_callback)
+    client.add_connect_callback(async_mock_connect_callback)
+    client.add_disconnect_callback(mock_disconnect_callback)
+    client.add_event_callback(mock_event_callback)
 
-    assert mock_connect_listener.call_count == 0
-    assert mock_disconnect_listener.call_count == 0
-    assert mock_event_listener.call_count == 0
+    assert mock_connect_callback.call_count == 0
+    assert mock_disconnect_callback.call_count == 0
+    assert mock_event_callback.call_count == 0
 
     await client.async_connect()
     assert client.connected
     await asyncio.sleep(1)
-    assert mock_connect_listener.call_count == 1
+    assert mock_connect_callback.call_count == 1
     assert any("We are connected!" in e.message for e in caplog.records)
 
     ws_messages.append(create_ws_message(ws_message_event))
     await client.async_listen()
     await asyncio.sleep(1)
     expected_event = websocket_event_from_payload(ws_message_event)
-    mock_event_listener.assert_called_once_with(expected_event)
+    mock_event_callback.assert_called_once_with(expected_event)
 
     # Add another message to the queue to keep the websocket open while we disconnect
     # from it:
     await client.async_disconnect()
     assert not client.connected
-    assert mock_disconnect_listener.call_count == 1
+    assert mock_disconnect_callback.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -213,16 +213,16 @@ async def test_reconnect(mock_api):
 
 
 @pytest.mark.asyncio
-async def test_remove_listener_callback(mock_api):
-    """Test that a removed listener callback doesn't get executed."""
-    mock_listener = Mock()
+async def test_remove_callback_callback(mock_api):
+    """Test that a removed callback callback doesn't get executed."""
+    mock_callback = Mock()
     client = WebsocketClient(mock_api)
-    remove = client.add_connect_listener(mock_listener)
+    remove = client.add_connect_callback(mock_callback)
     remove()
 
     await client.async_connect()
     assert client.connected
-    assert mock_listener.call_count == 0
+    assert mock_callback.call_count == 0
 
     await client.async_disconnect()
     assert not client.connected

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -184,7 +184,6 @@ async def test_callback(caplog, mock_api, ws_message_event, ws_messages):
 
     await client.async_connect()
     assert client.connected
-    await asyncio.sleep(1)
     assert mock_connect_callback.call_count == 1
     assert any("We are connected!" in e.message for e in caplog.records)
 


### PR DESCRIPTION
**Describe what the PR does:**

This PR does a couple things re: callbacks:

* Centralizes the logic in `simplipy.util`
* Enables refresh token callbacks to be synchronous functions *or* coroutines
* Changes method names/verbiage/etc. that previously referred to `listener` to now refer to `callback` (to standardize the language)

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [x] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
