### PR TITLE
Add appropriate guards to websocket actions

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,8 +226,6 @@ async def ws_client_fixture(
 
     ws_client.receive.side_effect = receive
 
-    ws_client.send_json.side_effect = Mock()
-
     async def reset_close():
         """Reset the websocket client close method."""
         ws_client.closed = True


### PR DESCRIPTION
**Describe what the PR does:**

From looking at Home Assistant logs, it's apparent that the SimpliSafe websocket, like the REST API, is a little flaky. This leads the current websocket implementation to connect/disconnect too many times, trigger the watchdog spuriously, etc. So, this PR adds some guards:

1. `async_connect` only attempts to connect if we aren't already connected.
2. Same with `async_disconnect`.
3. We only trigger the watchdog if its underlying task hasn't already been cancelled.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/python-simplisafe/issues/<ISSUE ID>
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
