### PR TITLE
Ensure API request method is consistently named

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -80,7 +80,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.websocket: WebsocketClient | None = None
 
         # Implement a version of the request coroutine, but with backoff/retry logic:
-        self.request = backoff.on_exception(
+        self.async_request = backoff.on_exception(
             backoff.expo,
             ClientResponseError,
             jitter=backoff.random_jitter,
@@ -319,7 +319,7 @@ class API:  # pylint: disable=too-many-instance-attributes
 
     async def async_update_subscription_data(self) -> None:
         """Get the latest subscription data."""
-        subscription_resp = await self.request(
+        subscription_resp = await self.async_request(
             "get", f"users/{self.user_id}/subscriptions", params={"activeOnly": "true"}
         )
         self.subscription_data = {

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -239,7 +239,7 @@ class System:
         longer visible in the SimpliSafe mobile and web apps.
         """
         if self._notifications:
-            await self._api.request(
+            await self._api.async_request(
                 "delete", f"subscriptions/{self.system_id}/messages"
             )
             self._notifications = []
@@ -267,7 +267,7 @@ class System:
         if num_events:
             params["numEvents"] = num_events
 
-        events_resp = await self._api.request(
+        events_resp = await self._api.async_request(
             "get", f"subscriptions/{self.system_id}/events", params=params
         )
 

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -42,7 +42,7 @@ class SystemV2(System):
 
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
-        await self._api.request(
+        await self._api.async_request(
             "post",
             f"subscriptions/{self.system_id}/state",
             params={"state": value.name.lower()},
@@ -52,7 +52,7 @@ class SystemV2(System):
 
     async def _async_set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""
-        await self._api.request(
+        await self._api.async_request(
             "post",
             f"subscriptions/{self.system_id}/pins",
             json=create_pin_payload(pins),
@@ -60,7 +60,7 @@ class SystemV2(System):
 
     async def _async_update_device_data(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""
-        sensor_resp = await self._api.request(
+        sensor_resp = await self._api.async_request(
             "get",
             f"subscriptions/{self.system_id}/settings",
             params={"settingsType": "all", "cached": str(cached).lower()},
@@ -91,7 +91,7 @@ class SystemV2(System):
         :type cached: ``bool``
         :rtype: ``dict[str, str]``
         """
-        pins_resp = await self._api.request(
+        pins_resp = await self._api.async_request(
             "get",
             f"subscriptions/{self.system_id}/pins",
             params={"settingsType": "all", "cached": str(cached).lower()},

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -368,7 +368,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
-        await self._api.request(
+        await self._api.async_request(
             "post", f"ss3/subscriptions/{self.system_id}/state/{value.name.lower()}"
         )
 
@@ -377,7 +377,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     async def _async_set_updated_pins(self, pins: dict) -> None:
         """Post new PINs."""
-        self.settings_data = await self._api.request(
+        self.settings_data = await self._api.async_request(
             "post",
             f"ss3/subscriptions/{self.system_id}/settings/pins",
             json=create_pin_payload(pins),
@@ -385,7 +385,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     async def _async_update_device_data(self, cached: bool = True) -> None:
         """Update sensors to the latest values."""
-        sensor_resp = await self._api.request(
+        sensor_resp = await self._api.async_request(
             "get",
             f"ss3/subscriptions/{self.system_id}/sensors",
             params={"forceUpdate": str(not cached).lower()},
@@ -396,7 +396,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
 
     async def _async_update_settings_data(self, cached: bool = True) -> None:
         """Get all system settings."""
-        settings_resp = await self._api.request(
+        settings_resp = await self._api.async_request(
             "get",
             f"ss3/subscriptions/{self.system_id}/settings/normal",
             params={"forceUpdate": str(not cached).lower()},
@@ -415,7 +415,9 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         for serial, sensor in self.sensor_data.items():
             sensor_type = get_device_type_from_data(sensor)
             if sensor_type == DeviceTypes.LOCK:
-                self.locks[serial] = Lock(self._api.request, self, sensor_type, serial)
+                self.locks[serial] = Lock(
+                    self._api.async_request, self, sensor_type, serial
+                )
             else:
                 self.sensors[serial] = SensorV3(self, sensor_type, serial)
 
@@ -474,7 +476,7 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
                 f"Using invalid values for system properties ({properties}): {err}"
             ) from None
 
-        settings_resp = await self._api.request(
+        settings_resp = await self._api.async_request(
             "post",
             f"ss3/subscriptions/{self.system_id}/settings/normal",
             json={


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/bachya/simplisafe-python/pull/263 failed to incorporate the `API` object's `request` method. This PR makes things consistent by renaming that method to `async_request`.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
