### PR TITLE
Add ability to disable and enable retry logic

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -258,15 +258,18 @@ class API:  # pylint: disable=too-many-instance-attributes
 
     def _wrap_request_method(self, request_retries: int) -> Callable:
         """Wrap the request method in backoff/retry logic."""
-        return cast(Callable, backoff.on_exception(
-            backoff.expo,
-            ClientResponseError,
-            jitter=backoff.random_jitter,
-            logger=LOGGER,
-            max_tries=request_retries,
-            on_backoff=self._async_handle_on_backoff,
-            on_giveup=self._handle_on_giveup,
-        )(self._async_request))
+        return cast(
+            Callable,
+            backoff.on_exception(
+                backoff.expo,
+                ClientResponseError,
+                jitter=backoff.random_jitter,
+                logger=LOGGER,
+                max_tries=request_retries,
+                on_backoff=self._async_handle_on_backoff,
+                on_giveup=self._handle_on_giveup,
+            )(self._async_request),
+        )
 
     def disable_request_retries(self) -> None:
         """Disable the request retry mechanism."""

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import datetime, timedelta
 from json.decoder import JSONDecodeError
 import sys
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from aiohttp import ClientSession
 from aiohttp.client_exceptions import ClientResponseError
@@ -258,7 +258,7 @@ class API:  # pylint: disable=too-many-instance-attributes
 
     def _wrap_request_method(self, request_retries: int) -> Callable:
         """Wrap the request method in backoff/retry logic."""
-        return backoff.on_exception(
+        return cast(Callable, backoff.on_exception(
             backoff.expo,
             ClientResponseError,
             jitter=backoff.random_jitter,
@@ -266,7 +266,7 @@ class API:  # pylint: disable=too-many-instance-attributes
             max_tries=request_retries,
             on_backoff=self._async_handle_on_backoff,
             on_giveup=self._handle_on_giveup,
-        )(self._async_request)
+        )(self._async_request))
 
     def disable_request_retries(self) -> None:
         """Disable the request retry mechanism."""


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds two new methods to the API object:

* `disable_request_retries()`
* `enable_request_retries()`

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.