### PR TITLE
Fix bug where V3 systems couldn't clear notifications

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -210,6 +210,10 @@ class System:
             self._api.subscription_data[self._sid]["location"]["system"]["version"],
         )
 
+    async def _async_clear_notifications(self) -> None:
+        """Clear active notifications."""
+        raise NotImplementedError()
+
     async def _async_set_state(self, value: SystemStates) -> None:
         """Raise if calling this undefined based method."""
         raise NotImplementedError()
@@ -229,6 +233,16 @@ class System:
     async def _async_update_subscription_data(self) -> None:
         """Update subscription data."""
         await self._api.async_update_subscription_data()
+
+    async def async_clear_notifications(self) -> None:
+        """Clear all active notifications.
+
+        This will remove the notifications from SimpliSafe's cloud, meaning they will no
+        longer visible in the SimpliSafe mobile and web apps.
+        """
+        if self._notifications:
+            await self._async_clear_notifications()
+            self._notifications = []
 
     def generate_device_objects(self) -> None:
         """Generate device objects for this system."""

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -230,18 +230,6 @@ class System:
         """Update subscription data."""
         await self._api.async_update_subscription_data()
 
-    async def async_clear_notifications(self) -> None:
-        """Clear all active notifications.
-
-        This will remove the notifications from SimpliSafe's cloud, meaning they will no
-        longer visible in the SimpliSafe mobile and web apps.
-        """
-        if self._notifications:
-            await self._api.async_request(
-                "delete", f"subscriptions/{self.system_id}/messages"
-            )
-            self._notifications = []
-
     def generate_device_objects(self) -> None:
         """Generate device objects for this system."""
         raise NotImplementedError()

--- a/simplipy/system/v2.py
+++ b/simplipy/system/v2.py
@@ -40,6 +40,12 @@ def create_pin_payload(pins: dict) -> dict[str, dict[str, dict[str, str]]]:
 class SystemV2(System):
     """Define a V2 (original) system."""
 
+    async def _async_clear_notifications(self) -> None:
+        """Clear active notifications."""
+        await self._api.async_request(
+            "delete", f"subscriptions/{self.system_id}/messages"
+        )
+
     async def _async_set_state(self, value: SystemStates) -> None:
         """Set the state of the system."""
         await self._api.async_request(

--- a/simplipy/system/v3.py
+++ b/simplipy/system/v3.py
@@ -423,6 +423,18 @@ class SystemV3(System):  # pylint: disable=too-many-public-methods
         for serial in self.camera_data:
             self.cameras[serial] = Camera(self, DeviceTypes.CAMERA, serial)
 
+    async def async_clear_notifications(self) -> None:
+        """Clear all active notifications.
+
+        This will remove the notifications from SimpliSafe's cloud, meaning they will no
+        longer visible in the SimpliSafe mobile and web apps.
+        """
+        if self._notifications:
+            await self._api.async_request(
+                "delete", f"ss3/subscriptions/{self.system_id}/messages"
+            )
+            self._notifications = []
+
     async def async_get_pins(self, cached: bool = True) -> dict[str, str]:
         """Return all of the set PINs, including master and duress.
 

--- a/tests/system/test_v2.py
+++ b/tests/system/test_v2.py
@@ -16,6 +16,28 @@ from tests.common import (
 
 
 @pytest.mark.asyncio
+async def test_clear_notifications(aresponses, v2_server, v2_settings_response):
+    """Test clearing all active notifications."""
+    v2_server.add(
+        "api.simplisafe.com",
+        f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/messages",
+        "delete",
+        response=aiohttp.web_response.json_response(v2_settings_response, status=200),
+    )
+
+    async with aiohttp.ClientSession() as session:
+        simplisafe = await API.async_from_auth(
+            TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
+        )
+        systems = await simplisafe.async_get_systems()
+        system = systems[TEST_SYSTEM_ID]
+        await system.async_clear_notifications()
+        assert system.notifications == []
+
+    aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.asyncio
 async def test_get_pins(aresponses, v2_pins_response, v2_server):
     """Test getting PINs associated with a V2 system."""
     v2_server.add(

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -47,7 +47,7 @@ async def test_clear_notifications(aresponses, v3_server, v3_settings_response):
     """Test getting the latest event."""
     v3_server.add(
         "api.simplisafe.com",
-        f"/v1/subscriptions/{TEST_SUBSCRIPTION_ID}/messages",
+        f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/messages",
         "delete",
         response=aiohttp.web_response.json_response(v3_settings_response, status=200),
     )

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -44,7 +44,7 @@ async def test_alarm_state(aresponses, v3_server):
 
 @pytest.mark.asyncio
 async def test_clear_notifications(aresponses, v3_server, v3_settings_response):
-    """Test getting the latest event."""
+    """Test clearing all active notifications."""
     v3_server.add(
         "api.simplisafe.com",
         f"/v1/ss3/subscriptions/{TEST_SUBSCRIPTION_ID}/messages",


### PR DESCRIPTION
**Describe what the PR does:**

It looks like clearing notifications on V3 systems has a new endpoint; this PR adds it.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
