### PR TITLE
Fix bug with how 401s are caught and refreshed

### DIFF
--- a/simplipy/websocket.py
+++ b/simplipy/websocket.py
@@ -228,7 +228,7 @@ class WebsocketClient:
     def _add_callback(
         callback_list: list, callback: Callable[..., Any]
     ) -> Callable[..., None]:
-        """Add a callback callback to a particular list."""
+        """Add a callback to a particular list."""
         callback_list.append(callback)
 
         def remove() -> None:
@@ -284,7 +284,7 @@ class WebsocketClient:
                 schedule_callback(callback, event)
 
     def add_connect_callback(self, callback: Callable[..., Any]) -> Callable[..., None]:
-        """Add a callback callback to be called after connecting.
+        """Add a callback to be called after connecting.
 
         :param callback: The method to call after connecting
         :type callback: ``Callable[..., None]``
@@ -294,7 +294,7 @@ class WebsocketClient:
     def add_disconnect_callback(
         self, callback: Callable[..., Any]
     ) -> Callable[..., None]:
-        """Add a callback callback to be called after disconnecting.
+        """Add a callback to be called after disconnecting.
 
         :param callback: The method to call after disconnecting
         :type callback: ``Callable[..., None]``
@@ -302,7 +302,7 @@ class WebsocketClient:
         return self._add_callback(self._disconnect_callbacks, callback)
 
     def add_event_callback(self, callback: Callable[..., Any]) -> Callable[..., None]:
-        """Add a callback callback to be called upon receiving an event.
+        """Add a callback to be called upon receiving an event.
 
         Note that callbacks should expect to receive a WebsocketEvent object as a
         parameter.

--- a/tests/system/test_v3.py
+++ b/tests/system/test_v3.py
@@ -1,6 +1,6 @@
 """Define tests for v3 System objects."""
 # pylint: disable=protected-access,too-many-arguments,unused-argument
-from datetime import datetime
+from datetime import datetime, timedelta
 import logging
 
 import aiohttp
@@ -234,7 +234,7 @@ async def test_no_state_change_on_failure(aresponses, v3_server):
         )
 
         # Manually set the expiration datetime to force a refresh token flow:
-        simplisafe._access_token_expire_dt = datetime.utcnow()
+        simplisafe._token_last_refreshed = datetime.utcnow() + timedelta(seconds=30)
 
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]

--- a/tests/test_lock.py
+++ b/tests/test_lock.py
@@ -1,6 +1,6 @@
 """Define tests for the Lock objects."""
 # pylint: disable=protected-access,unused-argument
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import aiohttp
 import pytest
@@ -109,7 +109,7 @@ async def test_no_state_change_on_failure(
         )
 
         # Manually set the expiration datetime to force a refresh token flow:
-        simplisafe._access_token_expire_dt = datetime.utcnow()
+        simplisafe._token_last_refreshed = datetime.utcnow() + timedelta(seconds=30)
 
         systems = await simplisafe.async_get_systems()
         system = systems[TEST_SYSTEM_ID]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -215,7 +215,7 @@ async def test_reconnect(mock_api):
 
 @pytest.mark.asyncio
 async def test_remove_callback_callback(mock_api):
-    """Test that a removed callback callback doesn't get executed."""
+    """Test that a removed callback doesn't get executed."""
     mock_callback = Mock()
     client = WebsocketClient(mock_api)
     remove = client.add_connect_callback(mock_callback)


### PR DESCRIPTION
**Describe what the PR does:**

The current method for refreshing access tokens when receiving an `HTTP 401` or `HTTP 403` assumed that tokens will always last 1 hour. I realize that, given some flakiness in the API, this isn't a safe assumption: we need to refresh _whenever_ we receive those codes.

This PR makes the appropriate adjustments and assumes that concurrent `401`s/`403`s within a 5-second window of a successful token refresh should be ignored.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
