### PR TITLE
Fix instance of too-strict typing

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -276,7 +276,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         self.async_request = self._wrap_request_method(self._request_retries)
 
     def add_refresh_token_callback(
-        self, callback: Callable[..., None]
+        self, callback: Callable[..., Any]
     ) -> Callable[..., None]:
         """Add a callback that should be triggered when tokens are refreshed.
 


### PR DESCRIPTION
**Describe what the PR does:**

`add_refresh_token_callback` can take coroutine functions, but the typing is too restrictive. This PR fixes things.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
