### PR TITLE
Fix bug in how subscription status is determined

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -306,7 +306,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         await self.async_update_subscription_data()
 
         for sid, subscription in self.subscription_data.items():
-            if not subscription["activated"] != 0:
+            if not subscription["status"]["isActive"] != 0:
                 LOGGER.info("Skipping inactive subscription: %s", sid)
                 continue
 

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -22,7 +22,7 @@ from tests.common import (
 @pytest.mark.asyncio
 async def test_deactivated_system(aresponses, server, subscriptions_response):
     """Test that API.async_get_systems doesn't return deactivated systems."""
-    subscriptions_response["subscriptions"][0]["activated"] = 0
+    subscriptions_response["subscriptions"][0]["status"]["isActive"] = False
 
     server.add(
         "api.simplisafe.com",


### PR DESCRIPTION
**Describe what the PR does:**

We were detecting a subscription's "active" status incorrectly. This PR fixes the bug.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
