### PR TITLE
Loosen dependency pin for voluptuous

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
           - --configfile=.bandit.yaml
         files: ^simplipy/.+\.py$
   - repo: https://github.com/python/black
-    rev: 21.7b0
+    rev: 22.3.0
     hooks:
       - id: black
         args:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ backoff = "^1.11.1"
 docutils = "<0.18"
 python = "^3.8.0"
 pytz = ">=2019.3"
-voluptuous = ">=0.11.7,<0.13.0"
+voluptuous = ">=0.13.0"
 websockets = ">=8.1,<11.0"
 
 [tool.poetry.dev-dependencies]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,4 @@ pytest-cov==2.12.1
 pytest==6.2.5
 pytz==2022.1
 types-pytz==2021.1.2
-voluptuous==0.12.2
+voluptuous==0.13.0


### PR DESCRIPTION
**Describe what the PR does:**

This PR loosens the dependency pinning for `voluptuous`. It tangentially updates the version of `black` used in `pre-commit` to resolve conflicts.

**Does this fix a specific issue?**

Fixes https://github.com/bachya/simplisafe-python/issues/318
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
