### PR TITLE
Loosen dependency pin for voluptuous

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ backoff = "^1.11.1"
 docutils = "<0.18"
 python = "^3.8.0"
 pytz = ">=2019.3"
-voluptuous = ">=0.13.0"
+voluptuous = ">=0.11.7"
 websockets = ">=8.1,<11.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
**Describe what the PR does:**

This PR loosens the dependency pinning for voluptuous. Adjusted to still allow old version.

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
