### PR TITLE
Remove docutils dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ classifiers = [
 [tool.poetry.dependencies]
 aiohttp = ">=3.8.0"
 backoff = "^1.11.1"
-docutils = "<0.18"
 python = "^3.8.0"
 pytz = ">=2019.3"
 voluptuous = ">=0.11.7"


### PR DESCRIPTION
**Describe what the PR does:**

Remove docutils dependency.
If needed, then it should be either in dev-dependencies, or only in a requirements file for CI

**Does this fix a specific issue?**

Related to https://github.com/home-assistant/core/pull/68897
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [ ] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
