### PR TITLE
Handle more errors during API creation process

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -147,7 +147,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 },
             )
             auth0_resp.raise_for_status()
-        except ClientResponseError as err:
+        except Exception as err:  # pylint: disable-broad-except
             raise SimplipyError(
                 f"Error while determining the Auth0 login URL: {err}"
             ) from err
@@ -228,7 +228,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 allow_redirects=False,
             )
             auth_resume_resp.raise_for_status()
-        except ClientResponseError as err:
+        except Exception as err:  # pylint: disable-broad-except
             raise SimplipyError(
                 f"Error while attempting to get authorization code: {err}"
             ) from err
@@ -250,7 +250,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 },
             )
             token_resp.raise_for_status()
-        except ClientResponseError as err:
+        except Exception as err:  # pylint: disable-broad-except
             raise SimplipyError(
                 f"Unknown error while attempting getting access token: {err}"
             ) from err
@@ -311,6 +311,10 @@ class API:  # pylint: disable=too-many-instance-attributes
                 raise InvalidCredentialsError("Invalid refresh token") from err
             raise RequestError(
                 f"Request error while attempting to refresh access token: {err}"
+            ) from err
+        except Exception as err:  # pylint: disable-broad-except
+            raise SimplipyError(
+                f"Error while attempting to refresh access token: {err}"
             ) from err
 
         await self._async_save_token_data_from_response(token_resp)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,7 +2,7 @@
 # pylint: disable=protected-access,too-many-arguments
 import asyncio
 from datetime import datetime, timedelta
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import aiohttp
 import pytest
@@ -275,10 +275,12 @@ async def test_client_async_from_refresh_token_http_error(aresponses, server):
 @pytest.mark.asyncio
 async def test_client_async_from_refresh_token_unknown_error():
     """Test an unknown error while creating a client from a refresh token."""
-    with patch("simplipy.API._async_api_request", AsyncMock(side_effect=Exception)):
-        async with aiohttp.ClientSession() as session:
-            with pytest.raises(SimplipyError):
-                await API.async_from_refresh_token(TEST_REFRESH_TOKEN, session=session)
+    with patch(
+        "simplipy.api.ClientSession",
+        MagicMock(request=AsyncMock(side_effect=Exception)),
+    ) as session:
+        with pytest.raises(SimplipyError):
+            await API.async_from_refresh_token(TEST_REFRESH_TOKEN, session=session)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
**Describe what the PR does:**

Sometimes, the SimpliSafe API will reject a connection, have a DNS issue, etc. We don't currently handle these when creating an API client. This PR adjusts things to wrap them in the appropriate `simplisafe-python` exception so that users can retry.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [x] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
