### PR TITLE
Properly store already-logged-in verification URL

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -157,7 +157,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         if not auth0_resp.headers["Location"].startswith("/"):
             # Login has already occurred (according to the session cookies we have), so
             # we already have the login verification URL:
-            api._login_verification_url = auth0_resp.headers["Location"]
+            api._login_verification_url = URL(auth0_resp.headers["Location"])
         else:
             # Attempt to login:
             login_resp = await session.request(


### PR DESCRIPTION
**Describe what the PR does:**

We were storing the login verification URL when already logged in as a string. This would raise an exception later on.

**Does this fix a specific issue?**

Fixes #337 

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
