### PR TITLE
Expand ability to capture fatal errors from response data

### DIFF
--- a/simplipy/errors.py
+++ b/simplipy/errors.py
@@ -1,6 +1,8 @@
 """Define package errors."""
 from __future__ import annotations
 
+from typing import Any
+
 
 class SimplipyError(Exception):
     """A base error."""
@@ -78,3 +80,19 @@ class NotConnectedError(WebsocketError):
     """Define a error when the websocket isn't properly connected to."""
 
     pass
+
+
+DATA_ERROR_MAP: dict[str, type[SimplipyError]] = {
+    "NoRemoteManagement": EndpointUnavailableError,
+    "PinError": PinError,
+}
+
+
+def raise_on_data_error(data: dict[str, Any]) -> None:
+    """Raise a specific error if the data payload suggests there is one."""
+    error_type = data.get("type")
+
+    if error_type not in DATA_ERROR_MAP:
+        return
+
+    raise DATA_ERROR_MAP[error_type](data["message"])


### PR DESCRIPTION
**Describe what the PR does:**

This PR follows up on https://github.com/bachya/simplisafe-python/pull/364, which was the initial "fix" for https://github.com/bachya/simplisafe-python/issues/362. In that PR, we would automatically return a `RequestError` for any fatal error. Although this works, https://github.com/bachya/simplisafe-python/issues/362 showed a PIN-related issue (wherein it would have been more appropriate to raise a `PinError`). So, this PR expands `simplipy`'s ability to look for specific errors in data payloads and raise the correct exception.

We now follow this approach:

1. If the response data suggests an exception that we know about (based on a mapping), raise that exception immediately.
2. Otherwise, fall back to existing logic.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
