### PR TITLE
Change how inactive systems are detected

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -348,7 +348,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         await self.async_update_subscription_data()
 
         for sid, subscription in self.subscription_data.items():
-            if subscription["activated"] == 0:
+            if subscription["activated"] == 0 or not subscription["status"]["isActive"]:
                 LOGGER.info("Skipping inactive subscription: %s", sid)
                 continue
 

--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -348,7 +348,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         await self.async_update_subscription_data()
 
         for sid, subscription in self.subscription_data.items():
-            if not subscription["status"]["isActive"]:
+            if subscription["activated"] == 0:
                 LOGGER.info("Skipping inactive subscription: %s", sid)
                 continue
 
@@ -357,7 +357,7 @@ class API:  # pylint: disable=too-many-instance-attributes
                 continue
 
             system: SystemV2 | SystemV3
-            if (_ := subscription["location"]["system"]["version"]) == 2:
+            if subscription["location"]["system"]["version"] == 2:
                 system = SystemV2(self, sid)
             else:
                 system = SystemV3(self, sid)

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -34,7 +34,7 @@ async def test_deactivated_system(
         authenticated_simplisafe_server: A authenticated API connection.
         subscriptions_response: An API response payload.
     """
-    subscriptions_response["subscriptions"][0]["status"]["isActive"] = False
+    subscriptions_response["subscriptions"][0]["activated"] = 0
 
     async with authenticated_simplisafe_server:
         authenticated_simplisafe_server.add(


### PR DESCRIPTION
**Describe what the PR does:**

https://github.com/home-assistant/core/issues/82875 showed us that the current method of determining whether a subscription is active is invalid. This PR changes how we do that detection to (hopefully) be more consistent.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
