### PR TITLE
Don't guard system ID or serial against missing data

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -209,8 +209,7 @@ class System:  # pylint: disable=too-many-public-methods
         return self._notifications
 
     @property
-    @guard_from_missing_data()
-    def serial(self) -> str | None:
+    def serial(self) -> str:
         """Return the system's serial number.
 
         Returns:
@@ -231,8 +230,7 @@ class System:  # pylint: disable=too-many-public-methods
         return self._state
 
     @property
-    @guard_from_missing_data()
-    def system_id(self) -> int | None:
+    def system_id(self) -> int:
         """Return the SimpliSafe identifier for this system.
 
         Returns:


### PR DESCRIPTION
**Describe what the PR does:**

Guarding these properties produces a typing nightmare when implementing. We should reasonably expect these properties to exist.

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
