### PR TITLE
Take another stab at detecting inactive subscriptions

### DIFF
--- a/simplipy/api.py
+++ b/simplipy/api.py
@@ -348,7 +348,7 @@ class API:  # pylint: disable=too-many-instance-attributes
         await self.async_update_subscription_data()
 
         for sid, subscription in self.subscription_data.items():
-            if subscription["activated"] == 0 or not subscription["status"]["isActive"]:
+            if not subscription["status"]["hasBaseStation"]:
                 LOGGER.info("Skipping inactive subscription: %s", sid)
                 continue
 

--- a/tests/system/test_base.py
+++ b/tests/system/test_base.py
@@ -34,7 +34,7 @@ async def test_deactivated_system(
         authenticated_simplisafe_server: A authenticated API connection.
         subscriptions_response: An API response payload.
     """
-    subscriptions_response["subscriptions"][0]["activated"] = 0
+    subscriptions_response["subscriptions"][0]["status"]["hasBaseStation"] = 0
 
     async with authenticated_simplisafe_server:
         authenticated_simplisafe_server.add(


### PR DESCRIPTION
**Describe what the PR does:**

This follows up on https://github.com/bachya/simplisafe-python/pull/383. Per https://github.com/home-assistant/core/issues/83494, this problem is more challenging than anticipated because it's unclear which data key from the SimpliSafe API equates to "active."

This PR takes a different stab at using a data key—`hasBaseStation`— that seems to be consistently `False` when a subscription is inactive (regardless of what subscription type is used).

**Does this fix a specific issue?**

N/A

**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
