### PR TITLE
fix: handle missing sensor fields gracefully (KeyError: 'name')

### DIFF
--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -84,7 +84,9 @@ class Device:
         Returns:
             The device name.
         """
-        return cast(str, self._system.sensor_data[self._serial].get("name", self._serial))
+        return cast(
+            str, self._system.sensor_data[self._serial].get("name", self._serial)
+        )
 
     @property
     def serial(self) -> str:
@@ -93,7 +95,9 @@ class Device:
         Returns:
             The device serial number.
         """
-        return cast(str, self._system.sensor_data[self._serial].get("serial", self._serial))
+        return cast(
+            str, self._system.sensor_data[self._serial].get("serial", self._serial)
+        )
 
     @property
     def type(self) -> DeviceTypes:
@@ -160,7 +164,9 @@ class DeviceV3(Device):
         """
         return cast(
             bool,
-            self._system.sensor_data[self._serial].get("flags", {}).get("lowBattery", False),
+            self._system.sensor_data[self._serial]
+            .get("flags", {})
+            .get("lowBattery", False),
         )
 
     @property
@@ -172,7 +178,9 @@ class DeviceV3(Device):
         """
         return cast(
             bool,
-            self._system.sensor_data[self._serial].get("flags", {}).get("offline", False),
+            self._system.sensor_data[self._serial]
+            .get("flags", {})
+            .get("offline", False),
         )
 
     @property
@@ -184,7 +192,9 @@ class DeviceV3(Device):
         Returns:
             A settings dictionary.
         """
-        return cast(dict[str, Any], self._system.sensor_data[self._serial].get("setting", {}))
+        return cast(
+            dict[str, Any], self._system.sensor_data[self._serial].get("setting", {})
+        )
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this device.

--- a/simplipy/device/__init__.py
+++ b/simplipy/device/__init__.py
@@ -84,7 +84,7 @@ class Device:
         Returns:
             The device name.
         """
-        return cast(str, self._system.sensor_data[self._serial]["name"])
+        return cast(str, self._system.sensor_data[self._serial].get("name", self._serial))
 
     @property
     def serial(self) -> str:
@@ -93,7 +93,7 @@ class Device:
         Returns:
             The device serial number.
         """
-        return cast(str, self._system.sensor_data[self._serial]["serial"])
+        return cast(str, self._system.sensor_data[self._serial].get("serial", self._serial))
 
     @property
     def type(self) -> DeviceTypes:
@@ -146,7 +146,9 @@ class DeviceV3(Device):
         """
         return cast(
             bool,
-            self._system.sensor_data[self._serial]["status"].get("malfunction", False),
+            self._system.sensor_data[self._serial]
+            .get("status", {})
+            .get("malfunction", False),
         )
 
     @property
@@ -156,7 +158,10 @@ class DeviceV3(Device):
         Returns:
             The device's low battery status.
         """
-        return cast(bool, self._system.sensor_data[self._serial]["flags"]["lowBattery"])
+        return cast(
+            bool,
+            self._system.sensor_data[self._serial].get("flags", {}).get("lowBattery", False),
+        )
 
     @property
     def offline(self) -> bool:
@@ -165,7 +170,10 @@ class DeviceV3(Device):
         Returns:
             The device's offline status.
         """
-        return cast(bool, self._system.sensor_data[self._serial]["flags"]["offline"])
+        return cast(
+            bool,
+            self._system.sensor_data[self._serial].get("flags", {}).get("offline", False),
+        )
 
     @property
     def settings(self) -> dict[str, Any]:
@@ -176,7 +184,7 @@ class DeviceV3(Device):
         Returns:
             A settings dictionary.
         """
-        return cast(dict[str, Any], self._system.sensor_data[self._serial]["setting"])
+        return cast(dict[str, Any], self._system.sensor_data[self._serial].get("setting", {}))
 
     def as_dict(self) -> dict[str, Any]:
         """Return dictionary version of this device.

--- a/tests/sensor/test_base.py
+++ b/tests/sensor/test_base.py
@@ -27,3 +27,25 @@ async def test_properties_base(
         assert sensor.type == DeviceTypes.KEYPAD
 
     aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.asyncio
+async def test_properties_base_missing_name_falls_back_to_serial(
+    aresponses: ResponsesMockServer,
+    authenticated_simplisafe_server_v3: ResponsesMockServer,
+) -> None:
+    """Test that name falls back to serial when the API omits the 'name' field.
+
+    Regression test for home-assistant/core#172599.
+    """
+    async with authenticated_simplisafe_server_v3, aiohttp.ClientSession() as session:
+        simplisafe = await API.async_from_auth(
+            TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
+        )
+        systems = await simplisafe.async_get_systems()
+        system = systems[TEST_SYSTEM_ID]
+        sensor = system.sensors["825"]
+        del system.sensor_data["825"]["name"]
+        assert sensor.name == "825"
+
+    aresponses.assert_plan_strictly_followed()

--- a/tests/sensor/test_v3.py
+++ b/tests/sensor/test_v3.py
@@ -44,3 +44,33 @@ async def test_properties_v3(
             assert siren.temperature == 42
 
     aresponses.assert_plan_strictly_followed()
+
+
+@pytest.mark.asyncio
+async def test_properties_v3_missing_fields_return_defaults(
+    aresponses: ResponsesMockServer,
+    authenticated_simplisafe_server_v3: ResponsesMockServer,
+) -> None:
+    """Test that V3 properties return safe defaults when API fields are absent.
+
+    Regression test for home-assistant/core#172599.
+    """
+    async with authenticated_simplisafe_server_v3, aiohttp.ClientSession() as session:
+        simplisafe = await API.async_from_auth(
+            TEST_AUTHORIZATION_CODE, TEST_CODE_VERIFIER, session=session
+        )
+        systems = await simplisafe.async_get_systems()
+        system = systems[TEST_SYSTEM_ID]
+        sensor: SensorV3 = cast(SensorV3, system.sensors["825"])
+
+        # Remove optional nested fields to simulate a sparse API response
+        system.sensor_data["825"].pop("status", None)
+        system.sensor_data["825"].pop("flags", None)
+        system.sensor_data["825"].pop("setting", None)
+
+        assert not sensor.error
+        assert not sensor.low_battery
+        assert not sensor.offline
+        assert sensor.settings == {}
+
+    aresponses.assert_plan_strictly_followed()


### PR DESCRIPTION
## Problem

SimpliSafe's API occasionally returns sensor data that omits the `name` field
(and potentially other fields such as `serial`, `status`, `flags`, `setting`).
When this happens, the `Device.name` property raises `KeyError: 'name'`,
crashing the Home Assistant SimpliSafe integration.

See: home-assistant/core#172599

## Root cause

`Device.name` and several `DeviceV3` properties use direct bracket access
(`sensor_data[serial]["name"]`) instead of `.get()`. There is no fallback
for fields the API may legally omit.

## Fix

Replace all unsafe `dict["key"]` lookups in `simplipy/device/__init__.py`
with `.get("key", default)` calls:

- `Device.name` → falls back to the device's serial number
- `Device.serial` → falls back to the serial number stored at init
- `DeviceV3.error` → guards the outer `"status"` key, defaults to `False`
- `DeviceV3.low_battery` → guards `"flags"` dict, defaults to `False`
- `DeviceV3.offline` → guards `"flags"` dict, defaults to `False`
- `DeviceV3.settings` → defaults to `{}`

## Testing

- All 94 existing tests pass with 100% coverage
- Two new regression tests simulate sparse API responses and confirm safe
  fallback behavior for both base `Device` and `DeviceV3` properties
- Verified working against a live SimpliSafe system via Home Assistant

## Related

Fixes home-assistant/core#172599