### PR TITLE
Update pin logic

### DIFF
--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -469,7 +469,7 @@ class System:  # pylint: disable=too-many-public-methods
             raise PinError(f"Refusing to create duplicate PIN: {pin}")
 
         max_pins = DEFAULT_MAX_USER_PINS + len(RESERVED_PIN_LABELS)
-        if len(latest_pins) == max_pins and label not in RESERVED_PIN_LABELS:
+        if len(latest_pins) == max_pins and label not in latest_pins:
             raise MaxUserPinsExceededError(
                 f"Refusing to create more than {max_pins} user PINs"
             )

--- a/simplipy/system/__init__.py
+++ b/simplipy/system/__init__.py
@@ -469,7 +469,8 @@ class System:  # pylint: disable=too-many-public-methods
             raise PinError(f"Refusing to create duplicate PIN: {pin}")
 
         max_pins = DEFAULT_MAX_USER_PINS + len(RESERVED_PIN_LABELS)
-        if len(latest_pins) == max_pins and label not in latest_pins:
+        rewritable_pins = RESERVED_PIN_LABELS | {*latest_pins}
+        if len(latest_pins) == max_pins and label not in rewritable_pins:
             raise MaxUserPinsExceededError(
                 f"Refusing to create more than {max_pins} user PINs"
             )


### PR DESCRIPTION
**Describe what the PR does:**

Changes `System.async_set_pin` to allow overwriting _any_ current pin when all 4 custom pins are set, rather than only reserved pins. The guard against creating more than 6 pins will check if the provided `label` is already in use, and allow the update.

**Does this fix a specific issue?**

I'm not aware that this is tracked as an issue yet. Currently [async_set_pin](https://github.com/bachya/simplisafe-python/blob/d9a974e5ba06d52787942f2fb081cc62d9392967/simplipy/system/__init__.py#L472) only allows the user to overwrite reserved pins when the user has maxed out their custom pins. 

**Checklist:**

- [ ] ~Confirm that one or more new tests are written for the new functionality.~ No new functionality
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] ~Update `README.md` with any new documentation.~ No documentation change. Changes make behavior more closely match documentation

Also checked _in vivo_: I've verified against my own account that this actually works, and will correctly update a _preexisting_ custom pin when all 4 custom pins and both reserve pins are set
